### PR TITLE
feat(asset-market): remember last selected AI model in localStorage

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,8 @@
       "Bash(openspec archive:*)",
       "Bash(openspec show:*)",
       "Bash(openspec validate:*)",
-      "Bash(openspec list:*)"
+      "Bash(openspec list:*)",
+      "Bash(git add:*)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,8 @@
       "Bash(openspec show:*)",
       "Bash(openspec validate:*)",
       "Bash(openspec list:*)",
-      "Bash(git add:*)"
+      "Bash(git add:*)",
+      "Bash(git push:*)"
     ]
   }
 }

--- a/src/app/(pages)/asset-market-info-fetcher/components/StepThreeDataSaver.tsx
+++ b/src/app/(pages)/asset-market-info-fetcher/components/StepThreeDataSaver.tsx
@@ -22,6 +22,7 @@ interface StepThreeDataSaverProps {
   onBack: () => void;
   onComplete: () => void;
   finalSaveResult: MarketInformation | null;
+  initialAssetMetaId?: number;
 }
 
 export function StepThreeDataSaver({
@@ -30,6 +31,7 @@ export function StepThreeDataSaver({
   onBack,
   onComplete,
   finalSaveResult,
+  initialAssetMetaId,
 }: StepThreeDataSaverProps) {
   const { t } = useTranslation('asset-market-info-fetcher');
   const [isFinalSaving, setIsFinalSaving] = useState(false);
@@ -59,6 +61,10 @@ export function StepThreeDataSaver({
               chineseName: asset.chineseName,
             })),
           );
+          // 若从资产详情页跳转而来，则预选该资产
+          if (initialAssetMetaId) {
+            setSelectedAssetIds([initialAssetMetaId]);
+          }
         }
       } catch (error) {
         console.error('获取资产列表失败:', error);

--- a/src/app/(pages)/asset-market-info-fetcher/components/StepTwoAIAnalyzer.tsx
+++ b/src/app/(pages)/asset-market-info-fetcher/components/StepTwoAIAnalyzer.tsx
@@ -15,6 +15,8 @@ import {
 } from '@renderer/components/ui/select';
 import { ProviderModel } from '@/types/modelProvider';
 
+const LAST_MODEL_SLUG_KEY = 'market_ai_last_model_slug';
+
 interface StepTwoAIAnalyzerProps {
   marketInfo: MarketInformation;
   onBack: () => void;
@@ -49,13 +51,14 @@ export function StepTwoAIAnalyzer({
         if (response.success && response.data?.models) {
           const models = response.data.models as ProviderModel[];
           setAvailableModels(models);
-          // 默认选中用户的默认模型，如果没有则选中第一个
+          // 优先使用上次选中的模型，其次是默认模型，最后是第一个可用模型
+          const lastSlug = typeof window !== 'undefined' ? localStorage.getItem(LAST_MODEL_SLUG_KEY) : null;
           const defaultModel = response.data.defaultModel;
-          if (defaultModel) {
-            setSelectedModelSlug(defaultModel);
-          } else if (models.length > 0) {
-            setSelectedModelSlug(models[0].slug);
-          }
+          const slugToUse =
+            (lastSlug && models.some((m) => m.slug === lastSlug) ? lastSlug : null) ??
+            (defaultModel && models.some((m) => m.slug === defaultModel) ? defaultModel : null) ??
+            (models.length > 0 ? models[0].slug : null);
+          setSelectedModelSlug(slugToUse);
         }
       } catch (error) {
         console.error('Failed to fetch available models:', error);
@@ -191,7 +194,12 @@ export function StepTwoAIAnalyzer({
             <label className="text-sm font-medium">{t('steps.step2.modelSelector.label')}</label>
             <Select
               value={selectedModelSlug || undefined}
-              onValueChange={setSelectedModelSlug}
+              onValueChange={(v) => {
+                setSelectedModelSlug(v);
+                if (typeof window !== 'undefined') {
+                  localStorage.setItem(LAST_MODEL_SLUG_KEY, v);
+                }
+              }}
               disabled={modelsLoading || availableModels.length === 0}
             >
               <SelectTrigger>

--- a/src/app/(pages)/asset-market-info-fetcher/components/market-fetcher.tsx
+++ b/src/app/(pages)/asset-market-info-fetcher/components/market-fetcher.tsx
@@ -25,10 +25,14 @@ import { StepOneContentFetcher } from './StepOneContentFetcher';
 import { StepTwoAIAnalyzer } from './StepTwoAIAnalyzer';
 import { StepThreeDataSaver } from './StepThreeDataSaver';
 import { useTranslation } from 'react-i18next';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 export function CombinedStepperMarketFetcher() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const initialAssetMetaId = searchParams.get('assetMetaId')
+    ? Number(searchParams.get('assetMetaId'))
+    : undefined;
   const { t } = useTranslation('asset-market-info-fetcher');
   const [activeStep, setActiveStep] = useState(1);
   const [inputMode, setInputMode] = useState<'url' | 'manual' | null>(null);
@@ -79,8 +83,12 @@ export function CombinedStepperMarketFetcher() {
   const handleStepThreeComplete = () => {
     setFinalSaveResult(getCurrentMarketInfo());
     resetForms();
-    // 跳转到 asset-market-info
-    router.push('/asset-market-info');
+    // 若从资产详情页跳转而来，则跳回该页面；否则跳到市场信息列表
+    if (initialAssetMetaId) {
+      router.push(`/asset-meta/${initialAssetMetaId}`);
+    } else {
+      router.push('/asset-market-info');
+    }
   };
 
   // 控制步骤切换的函数
@@ -202,6 +210,7 @@ export function CombinedStepperMarketFetcher() {
                   onBack={() => setActiveStep(2)}
                   onComplete={handleStepThreeComplete}
                   finalSaveResult={finalSaveResult}
+                  initialAssetMetaId={initialAssetMetaId}
                 />
               )}
             </StepperContent>
@@ -211,3 +220,4 @@ export function CombinedStepperMarketFetcher() {
     </div>
   );
 }
+

--- a/src/app/(pages)/asset-market-info/detail/[id]/asset-market-info-detail.tsx
+++ b/src/app/(pages)/asset-market-info/detail/[id]/asset-market-info-detail.tsx
@@ -2,19 +2,66 @@
 
 import { useState, useEffect } from 'react';
 import { Alert, AlertDescription, AlertTitle } from '@renderer/components/ui/alert';
-import { AlertCircle, RefreshCw, ArrowLeft, ExternalLink } from 'lucide-react';
+import { AlertCircle, RefreshCw, ArrowLeft, ExternalLink, Pencil } from 'lucide-react';
 import { Button } from '@renderer/components/ui/button';
 import { Badge } from '@renderer/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@renderer/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@renderer/components/ui/dialog';
+import { Input } from '@renderer/components/ui/input';
+import { Label } from '@renderer/components/ui/label';
+import { Textarea } from '@renderer/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@renderer/components/ui/select';
 import Link from 'next/link';
 import { format } from 'date-fns';
 import { zhCN } from 'date-fns/locale';
 import { AssetMarketInfoType } from '@/types/marketInfo';
+import { useTranslation } from 'react-i18next';
+
+type EditForm = {
+  title: string;
+  sentiment: string;
+  importance: string;
+  summary: string;
+  marketImpact: string;
+  keyTopics: string;
+  keyDataPoints: string;
+  sourceUrl: string;
+  sourceName: string;
+};
 
 export function AssetMarketInfoDetail({ marketInfoId }: { marketInfoId: number }) {
+  const { t } = useTranslation('asset-market-info');
   const [marketInfo, setMarketInfo] = useState<AssetMarketInfoType | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // 编辑弹窗状态
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState<EditForm>({
+    title: '',
+    sentiment: '',
+    importance: '',
+    summary: '',
+    marketImpact: '',
+    keyTopics: '',
+    keyDataPoints: '',
+    sourceUrl: '',
+    sourceName: '',
+  });
 
   const fetchMarketInfoDetail = async () => {
     try {
@@ -25,13 +72,13 @@ export function AssetMarketInfoDetail({ marketInfoId }: { marketInfoId: number }
 
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(errorData.message || '获取市场信息详情失败');
+        throw new Error(errorData.message || t('error.fetchDetailFailed'));
       }
 
       const result = await response.json();
       setMarketInfo(result.data);
     } catch (err) {
-      setError(err instanceof Error ? err.message : '未知错误');
+      setError(err instanceof Error ? err.message : t('error.unknown'));
     } finally {
       setLoading(false);
     }
@@ -40,6 +87,59 @@ export function AssetMarketInfoDetail({ marketInfoId }: { marketInfoId: number }
   useEffect(() => {
     fetchMarketInfoDetail();
   }, [marketInfoId]);
+
+  const openEditDialog = () => {
+    if (!marketInfo) return;
+    setEditForm({
+      title: marketInfo.title,
+      sentiment: marketInfo.sentiment,
+      importance: marketInfo.importance,
+      summary: marketInfo.summary,
+      marketImpact: marketInfo.marketImpact,
+      keyTopics: marketInfo.keyTopics ?? '',
+      keyDataPoints: marketInfo.keyDataPoints ?? '',
+      sourceUrl: marketInfo.sourceUrl ?? '',
+      sourceName: marketInfo.sourceName ?? '',
+    });
+    setSaveError(null);
+    setEditDialogOpen(true);
+  };
+
+  const handleSave = async () => {
+    try {
+      setSaving(true);
+      setSaveError(null);
+
+      const response = await fetch('/api/asset/market-info', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: marketInfoId,
+          title: editForm.title,
+          sentiment: editForm.sentiment,
+          importance: editForm.importance,
+          summary: editForm.summary,
+          marketImpact: editForm.marketImpact,
+          keyTopics: editForm.keyTopics || null,
+          keyDataPoints: editForm.keyDataPoints || null,
+          sourceUrl: editForm.sourceUrl || null,
+          sourceName: editForm.sourceName || null,
+        }),
+      });
+
+      const result = await response.json();
+      if (!result.success) {
+        throw new Error(result.message || t('error.saveFailed'));
+      }
+
+      setMarketInfo(result.data.data);
+      setEditDialogOpen(false);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : t('error.saveFailed'));
+    } finally {
+      setSaving(false);
+    }
+  };
 
   // 获取情感标签的颜色
   const getSentimentColor = (sentiment: string) => {
@@ -78,13 +178,13 @@ export function AssetMarketInfoDetail({ marketInfoId }: { marketInfoId: number }
     return (
       <Alert variant="destructive">
         <AlertCircle className="h-4 w-4" />
-        <AlertTitle>错误</AlertTitle>
+        <AlertTitle>{t('error.title')}</AlertTitle>
         <AlertDescription>
           {error}
           <div className="mt-4">
             <Button onClick={fetchMarketInfoDetail} variant="outline">
               <RefreshCw className="mr-2 h-4 w-4" />
-              重新加载
+              {t('error.reload')}
             </Button>
           </div>
         </AlertDescription>
@@ -95,21 +195,25 @@ export function AssetMarketInfoDetail({ marketInfoId }: { marketInfoId: number }
   if (!marketInfo) {
     return (
       <Alert>
-        <AlertTitle>暂无数据</AlertTitle>
-        <AlertDescription>未找到指定的市场信息。</AlertDescription>
+        <AlertTitle>{t('detail.noData.title')}</AlertTitle>
+        <AlertDescription>{t('detail.noData.description')}</AlertDescription>
       </Alert>
     );
   }
 
   return (
     <div className="space-y-6">
-      {/* 返回按钮 */}
-      <div className="flex items-center gap-4">
+      {/* 返回按钮 + 编辑按钮 */}
+      <div className="flex items-center justify-between gap-4">
         <Button variant="outline" asChild>
           <Link href="/asset-market-info">
             <ArrowLeft className="mr-2 h-4 w-4" />
-            返回列表
+            {t('detail.backToList')}
           </Link>
+        </Button>
+        <Button onClick={openEditDialog}>
+          <Pencil className="mr-2 h-4 w-4" />
+          {t('detail.edit')}
         </Button>
       </div>
 
@@ -118,13 +222,13 @@ export function AssetMarketInfoDetail({ marketInfoId }: { marketInfoId: number }
         <h1 className="text-3xl font-bold">{marketInfo.title}</h1>
         <div className="flex flex-wrap items-center gap-3">
           <Badge variant="outline" className={getSentimentColor(marketInfo.sentiment)}>
-            情感: {marketInfo.sentiment}
+            {t('detail.sentiment')}: {t(`sentiment.${marketInfo.sentiment}`, { defaultValue: marketInfo.sentiment })}
           </Badge>
           <Badge variant="outline" className={getImportanceColor(marketInfo.importance)}>
-            重要性: {marketInfo.importance}/10
+            {t('detail.importanceLabel')}: {marketInfo.importance}/10
           </Badge>
           <span className="text-muted-foreground text-sm">
-            发布时间: {format(new Date(marketInfo.createdAt), 'yyyy年MM月dd日 HH:mm', { locale: zhCN })}
+            {t('detail.publishedAt')}: {format(new Date(marketInfo.createdAt), 'yyyy年MM月dd日 HH:mm', { locale: zhCN })}
           </span>
         </div>
       </div>
@@ -133,7 +237,7 @@ export function AssetMarketInfoDetail({ marketInfoId }: { marketInfoId: number }
       {marketInfo.assetMetas && marketInfo.assetMetas.length > 0 && (
         <Card>
           <CardHeader>
-            <CardTitle className="text-lg">关联资产</CardTitle>
+            <CardTitle className="text-lg">{t('detail.sections.relatedAssets')}</CardTitle>
           </CardHeader>
           <CardContent>
             <div className="flex flex-wrap gap-2">
@@ -155,7 +259,7 @@ export function AssetMarketInfoDetail({ marketInfoId }: { marketInfoId: number }
       {/* 摘要 */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-lg">摘要</CardTitle>
+          <CardTitle className="text-lg">{t('detail.sections.summary')}</CardTitle>
         </CardHeader>
         <CardContent>
           <p className="text-muted-foreground whitespace-pre-wrap">{marketInfo.summary}</p>
@@ -165,7 +269,7 @@ export function AssetMarketInfoDetail({ marketInfoId }: { marketInfoId: number }
       {/* 市场影响 */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-lg">市场影响</CardTitle>
+          <CardTitle className="text-lg">{t('detail.sections.marketImpact')}</CardTitle>
         </CardHeader>
         <CardContent>
           <p className="text-muted-foreground whitespace-pre-wrap">{marketInfo.marketImpact}</p>
@@ -176,7 +280,7 @@ export function AssetMarketInfoDetail({ marketInfoId }: { marketInfoId: number }
       {marketInfo.keyTopics && (
         <Card>
           <CardHeader>
-            <CardTitle className="text-lg">关键话题</CardTitle>
+            <CardTitle className="text-lg">{t('detail.sections.keyTopics')}</CardTitle>
           </CardHeader>
           <CardContent>
             <p className="text-muted-foreground whitespace-pre-wrap">{marketInfo.keyTopics}</p>
@@ -188,7 +292,7 @@ export function AssetMarketInfoDetail({ marketInfoId }: { marketInfoId: number }
       {marketInfo.keyDataPoints && (
         <Card>
           <CardHeader>
-            <CardTitle className="text-lg">关键数据点</CardTitle>
+            <CardTitle className="text-lg">{t('detail.sections.keyDataPoints')}</CardTitle>
           </CardHeader>
           <CardContent>
             <p className="text-muted-foreground whitespace-pre-wrap">{marketInfo.keyDataPoints}</p>
@@ -200,7 +304,7 @@ export function AssetMarketInfoDetail({ marketInfoId }: { marketInfoId: number }
       {marketInfo.originalContent && (
         <Card>
           <CardHeader>
-            <CardTitle className="text-lg">原始内容</CardTitle>
+            <CardTitle className="text-lg">{t('detail.sections.originalContent')}</CardTitle>
           </CardHeader>
           <CardContent>
             <div className="bg-muted p-4 rounded-lg">
@@ -214,17 +318,17 @@ export function AssetMarketInfoDetail({ marketInfoId }: { marketInfoId: number }
       {(marketInfo.sourceName || marketInfo.sourceUrl) && (
         <Card>
           <CardHeader>
-            <CardTitle className="text-lg">信息来源</CardTitle>
+            <CardTitle className="text-lg">{t('detail.sections.source')}</CardTitle>
           </CardHeader>
           <CardContent className="space-y-2">
             {marketInfo.sourceName && (
               <p className="text-sm">
-                <span className="font-medium">来源名称:</span> {marketInfo.sourceName}
+                <span className="font-medium">{t('detail.sections.sourceName')}:</span> {marketInfo.sourceName}
               </p>
             )}
             {marketInfo.sourceUrl && (
               <p className="text-sm">
-                <span className="font-medium">来源链接:</span>{' '}
+                <span className="font-medium">{t('detail.sections.sourceUrl')}:</span>{' '}
                 <a
                   href={marketInfo.sourceUrl}
                   target="_blank"
@@ -245,13 +349,133 @@ export function AssetMarketInfoDetail({ marketInfoId }: { marketInfoId: number }
         <CardContent className="py-4">
           <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
             <span>ID: {marketInfo.id}</span>
-            <span>内容模式: {marketInfo.contentMode === 'ai_summary' ? 'AI摘要' : '原文保留'}</span>
             <span>
-              更新时间: {format(new Date(marketInfo.updatedAt), 'yyyy年MM月dd日 HH:mm', { locale: zhCN })}
+              {t('detail.contentMode')}: {marketInfo.contentMode === 'ai_summary' ? t('detail.contentModeAI') : t('detail.contentModeOriginal')}
+            </span>
+            <span>
+              {t('detail.updatedAt')}: {format(new Date(marketInfo.updatedAt), 'yyyy年MM月dd日 HH:mm', { locale: zhCN })}
             </span>
           </div>
         </CardContent>
       </Card>
+
+      {/* 编辑弹窗 */}
+      <Dialog open={editDialogOpen} onOpenChange={setEditDialogOpen}>
+        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>{t('edit.title')}</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            {saveError && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>{saveError}</AlertDescription>
+              </Alert>
+            )}
+            <div className="space-y-2">
+              <Label htmlFor="edit-title">{t('edit.fields.title')}</Label>
+              <Input
+                id="edit-title"
+                value={editForm.title}
+                onChange={(e) => setEditForm((p) => ({ ...p, title: e.target.value }))}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="edit-sentiment">{t('edit.fields.sentiment')}</Label>
+                <Select
+                  key={editForm.sentiment + String(editDialogOpen)}
+                  defaultValue={editForm.sentiment}
+                  onValueChange={(v) => setEditForm((p) => ({ ...p, sentiment: v }))}
+                >
+                  <SelectTrigger id="edit-sentiment">
+                    <SelectValue placeholder={t('edit.fields.sentimentPlaceholder')} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="positive">{t('sentiment.positive')}</SelectItem>
+                    <SelectItem value="neutral">{t('sentiment.neutral')}</SelectItem>
+                    <SelectItem value="negative">{t('sentiment.negative')}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="edit-importance">{t('edit.fields.importance')}</Label>
+                <Input
+                  id="edit-importance"
+                  type="number"
+                  min={1}
+                  max={10}
+                  value={editForm.importance}
+                  onChange={(e) => setEditForm((p) => ({ ...p, importance: e.target.value }))}
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-summary">{t('edit.fields.summary')}</Label>
+              <Textarea
+                id="edit-summary"
+                rows={4}
+                value={editForm.summary}
+                onChange={(e) => setEditForm((p) => ({ ...p, summary: e.target.value }))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-market-impact">{t('edit.fields.marketImpact')}</Label>
+              <Textarea
+                id="edit-market-impact"
+                rows={3}
+                value={editForm.marketImpact}
+                onChange={(e) => setEditForm((p) => ({ ...p, marketImpact: e.target.value }))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-key-topics">{t('edit.fields.keyTopics')}</Label>
+              <Textarea
+                id="edit-key-topics"
+                rows={2}
+                value={editForm.keyTopics}
+                onChange={(e) => setEditForm((p) => ({ ...p, keyTopics: e.target.value }))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-key-data-points">{t('edit.fields.keyDataPoints')}</Label>
+              <Textarea
+                id="edit-key-data-points"
+                rows={2}
+                value={editForm.keyDataPoints}
+                onChange={(e) => setEditForm((p) => ({ ...p, keyDataPoints: e.target.value }))}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="edit-source-name">{t('edit.fields.sourceName')}</Label>
+                <Input
+                  id="edit-source-name"
+                  value={editForm.sourceName}
+                  onChange={(e) => setEditForm((p) => ({ ...p, sourceName: e.target.value }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="edit-source-url">{t('edit.fields.sourceUrl')}</Label>
+                <Input
+                  id="edit-source-url"
+                  value={editForm.sourceUrl}
+                  onChange={(e) => setEditForm((p) => ({ ...p, sourceUrl: e.target.value }))}
+                />
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditDialogOpen(false)} disabled={saving}>
+              {t('edit.buttons.cancel')}
+            </Button>
+            <Button onClick={handleSave} disabled={saving}>
+              {saving ? t('edit.buttons.saving') : t('edit.buttons.save')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }
+

--- a/src/app/(pages)/asset-meta/[id]/asset-market-info-detail.tsx
+++ b/src/app/(pages)/asset-meta/[id]/asset-market-info-detail.tsx
@@ -20,7 +20,6 @@ import { LatestMarketInfoView } from './components/LatestMarketInfoView';
 import { HistoryMarketInfoView } from './components/HistoryMarketInfoView';
 import { CompanyInfoView } from './components/CompanyInfoView';
 import { AddCompanyInfoDialog } from './components/AddCompanyInfoDialog';
-import { AddMarketInfoDialog } from './components/AddMarketInfoDialog';
 import { DeleteConfirmationDialog } from './components/DeleteConfirmationDialog';
 import { InvestmentMemoView } from './components/InvestmentMemoView';
 import { BasicInfoView } from './components/BasicInfoView';
@@ -70,9 +69,6 @@ export function AssetMarketInfoDetail({ assetMetaId }: { assetMetaId: number }) 
   const [addCompanyInfoDialogOpen, setAddCompanyInfoDialogOpen] = useState(false);
   const [savingCompanyInfo, setSavingCompanyInfo] = useState(false);
   const [editingCompanyInfo, setEditingCompanyInfo] = useState<AssetCompanyInfoType | null>(null);
-
-  // 新增状态用于添加市场纪要模态框
-  const [addMarketInfoDialogOpen, setAddMarketInfoDialogOpen] = useState(false);
 
   // 投资笔记编辑弹窗状态
   const [investmentMemoDialogOpen, setInvestmentMemoDialogOpen] = useState(false);
@@ -276,9 +272,9 @@ export function AssetMarketInfoDetail({ assetMetaId }: { assetMetaId: number }) 
     }
   };
 
-  // 打开添加市场纪要对话框
-  const openAddMarketInfoDialog = () => {
-    setAddMarketInfoDialogOpen(true);
+  // 跳转到市场纪要抓取页面
+  const goToMarketInfoFetcher = () => {
+    router.push(`/asset-market-info-fetcher?assetMetaId=${assetMetaId}`);
   };
 
   // 打开添加公司信息对话框
@@ -290,22 +286,6 @@ export function AssetMarketInfoDetail({ assetMetaId }: { assetMetaId: number }) 
   const openEditCompanyInfoDialog = (info: AssetCompanyInfoType) => {
     setEditingCompanyInfo(info);
     setAddCompanyInfoDialogOpen(true);
-  };
-
-  // 关闭添加市场纪要对话框
-  const closeAddMarketInfoDialog = () => {
-    setAddMarketInfoDialogOpen(false);
-  };
-
-  // 保存成功后的回调函数
-  const handleAddMarketInfoSuccess = () => {
-    setAddMarketInfoDialogOpen(false);
-    // 刷新数据以显示新添加的市场纪要
-    if (activeTab === 'latest') {
-      fetchLatestMarketInfo();
-    } else if (activeTab === 'history') {
-      fetchMarketInfoList(pagination.page);
-    }
   };
 
   // 关闭添加公司信息对话框
@@ -469,7 +449,7 @@ export function AssetMarketInfoDetail({ assetMetaId }: { assetMetaId: number }) 
         activeTab={activeTab}
         setActiveTab={setActiveTab}
         onRefresh={fetchData}
-        onAddMarketInfo={openAddMarketInfoDialog}
+        onAddMarketInfo={goToMarketInfoFetcher}
         onAddCompanyInfo={openAddCompanyInfoDialog}
         onAddInvestmentMemo={
           !assetMeta?.investmentMemo ? () => setInvestmentMemoDialogOpen(true) : undefined
@@ -622,13 +602,6 @@ export function AssetMarketInfoDetail({ assetMetaId }: { assetMetaId: number }) 
           </DialogFooter>
         </DialogContent>
       </Dialog>
-      <AddMarketInfoDialog
-        open={addMarketInfoDialogOpen}
-        onOpenChange={setAddMarketInfoDialogOpen}
-        assetMetaId={assetMetaId}
-        onSuccess={handleAddMarketInfoSuccess}
-        onCancel={closeAddMarketInfoDialog}
-      />
     </div>
   );
 }

--- a/src/app/(pages)/report/report-list.tsx
+++ b/src/app/(pages)/report/report-list.tsx
@@ -22,6 +22,8 @@ import { useTranslation } from 'react-i18next';
 import { get } from '@/app/lib/request';
 import { ProviderModel } from '@/types/modelProvider';
 
+const LAST_MODEL_SLUG_KEY = 'market_ai_last_model_slug';
+
 export function ReportList() {
   const { t } = useTranslation('report');
   const router = useRouter();
@@ -44,13 +46,14 @@ export function ReportList() {
         if (response.success && response.data?.models) {
           const models = response.data.models as ProviderModel[];
           setAvailableModels(models);
-          // 默认选中用户的默认模型，如果没有则选中第一个
+          // 优先使用上次选中的模型，其次是默认模型，最后是第一个可用模型
+          const lastSlug = typeof window !== 'undefined' ? localStorage.getItem(LAST_MODEL_SLUG_KEY) : null;
           const defaultModel = response.data.defaultModel;
-          if (defaultModel) {
-            setSelectedModelSlug(defaultModel);
-          } else if (models.length > 0) {
-            setSelectedModelSlug(models[0].slug);
-          }
+          const slugToUse =
+            (lastSlug && models.some((m) => m.slug === lastSlug) ? lastSlug : null) ??
+            (defaultModel && models.some((m) => m.slug === defaultModel) ? defaultModel : null) ??
+            (models.length > 0 ? models[0].slug : null);
+          setSelectedModelSlug(slugToUse);
         }
       } catch (error) {
         console.error('Failed to fetch available models:', error);
@@ -143,7 +146,12 @@ export function ReportList() {
           {/* 模型选择器 */}
           <Select
             value={selectedModelSlug || undefined}
-            onValueChange={setSelectedModelSlug}
+            onValueChange={(v) => {
+              setSelectedModelSlug(v);
+              if (typeof window !== 'undefined') {
+                localStorage.setItem(LAST_MODEL_SLUG_KEY, v);
+              }
+            }}
             disabled={modelsLoading || availableModels.length === 0}
           >
             <SelectTrigger className="w-[180]">

--- a/src/app/api/asset/market-info/route.ts
+++ b/src/app/api/asset/market-info/route.ts
@@ -15,6 +15,13 @@ class AssetMarketInfosController extends BaseController {
   }
 
   @WithRequestContext()
+  static async PUT(request: Request) {
+    const body = await request.json();
+    const marketController = new MarketBizController();
+    return Response.json(await marketController.updateMarketInfo(body));
+  }
+
+  @WithRequestContext()
   static async DELETE(request: Request) {
     // 解析查询参数
     const url = new URL(request.url);
@@ -29,4 +36,5 @@ class AssetMarketInfosController extends BaseController {
 }
 
 export const GET = AssetMarketInfosController.GET;
+export const PUT = AssetMarketInfosController.PUT;
 export const DELETE = AssetMarketInfosController.DELETE;

--- a/src/app/components/nav-main.tsx
+++ b/src/app/components/nav-main.tsx
@@ -10,6 +10,8 @@ import {
 } from '@renderer/components/ui/sidebar';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useChatStore } from '@renderer/store/chat';
+import { chatSelectors } from '@renderer/store/chat/selectors';
 
 export function NavMain({
   items,
@@ -21,6 +23,7 @@ export function NavMain({
   }[];
 }) {
   const pathname = usePathname();
+  const isAIGenerating = useChatStore(chatSelectors.isAIGenerating);
 
   return (
     <SidebarGroup>
@@ -39,11 +42,19 @@ export function NavMain({
         <SidebarMenu>
           {items.map((item) => {
             const isActive = pathname === item.url;
+            const showGeneratingBadge = item.url === '/chat' && isAIGenerating && !isActive;
             return (
               <Link href={item.url} key={item.title}>
                 <SidebarMenuItem>
                   <SidebarMenuButton tooltip={item.title} isActive={isActive}>
-                    {item.icon && <item.icon />}
+                    {item.icon && (
+                      <span className="relative">
+                        <item.icon />
+                        {showGeneratingBadge && (
+                          <span className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-primary animate-pulse" />
+                        )}
+                      </span>
+                    )}
                     <span>{item.title}</span>
                   </SidebarMenuButton>
                 </SidebarMenuItem>

--- a/src/locales/en-US/asset-market-info.json
+++ b/src/locales/en-US/asset-market-info.json
@@ -1,15 +1,63 @@
 {
   "actions": {
-    "addInfo": "Add Info",
+    "addInfo": "Add Market Info",
     "reload": "Reload"
   },
   "dateRange": {
     "label": "Date Range:",
     "to": "to"
   },
+  "detail": {
+    "backToList": "Back to List",
+    "edit": "Edit",
+    "noData": {
+      "description": "The specified market information was not found.",
+      "title": "No Data"
+    },
+    "publishedAt": "Published At",
+    "updatedAt": "Updated At",
+    "contentMode": "Content Mode",
+    "contentModeAI": "AI Summary",
+    "contentModeOriginal": "Original",
+    "sections": {
+      "relatedAssets": "Related Assets",
+      "summary": "Summary",
+      "marketImpact": "Market Impact",
+      "keyTopics": "Key Topics",
+      "keyDataPoints": "Key Data Points",
+      "originalContent": "Original Content",
+      "source": "Source",
+      "sourceName": "Source Name",
+      "sourceUrl": "Source URL"
+    },
+    "sentiment": "Sentiment",
+    "importanceLabel": "Importance"
+  },
+  "edit": {
+    "title": "Edit Market Info",
+    "fields": {
+      "title": "Title",
+      "sentiment": "Sentiment",
+      "sentimentPlaceholder": "Select sentiment",
+      "importance": "Importance (1-10)",
+      "summary": "Summary",
+      "marketImpact": "Market Impact",
+      "keyTopics": "Key Topics",
+      "keyDataPoints": "Key Data Points",
+      "sourceName": "Source Name",
+      "sourceUrl": "Source URL"
+    },
+    "buttons": {
+      "cancel": "Cancel",
+      "save": "Save",
+      "saving": "Saving..."
+    }
+  },
   "error": {
     "fetchFailed": "Failed to fetch data",
+    "fetchDetailFailed": "Failed to fetch market info detail",
     "reload": "Reload",
+    "saveFailed": "Save failed",
     "title": "Error",
     "unknown": "Unknown error"
   },

--- a/src/locales/zh-CN/asset-market-info.json
+++ b/src/locales/zh-CN/asset-market-info.json
@@ -1,15 +1,63 @@
 {
   "actions": {
-    "addInfo": "添加信息",
-    "reload": "重新加载"
+    "addInfo": "添加市场信息",
+    "reload": "重新加载信息"
   },
   "dateRange": {
     "label": "时间范围:",
     "to": "至"
   },
+  "detail": {
+    "backToList": "返回列表",
+    "edit": "编辑",
+    "noData": {
+      "description": "未找到指定的市场信息。",
+      "title": "暂无数据"
+    },
+    "publishedAt": "发布时间",
+    "updatedAt": "更新时间",
+    "contentMode": "内容模式",
+    "contentModeAI": "AI摘要",
+    "contentModeOriginal": "原文保留",
+    "sections": {
+      "relatedAssets": "关联资产",
+      "summary": "摘要",
+      "marketImpact": "市场影响",
+      "keyTopics": "关键话题",
+      "keyDataPoints": "关键数据点",
+      "originalContent": "原始内容",
+      "source": "信息来源",
+      "sourceName": "来源名称",
+      "sourceUrl": "来源链接"
+    },
+    "sentiment": "情感",
+    "importanceLabel": "重要性"
+  },
+  "edit": {
+    "title": "编辑市场信息",
+    "fields": {
+      "title": "标题",
+      "sentiment": "情感倾向",
+      "sentimentPlaceholder": "请选择情感倾向",
+      "importance": "重要性 (1-10)",
+      "summary": "摘要",
+      "marketImpact": "市场影响",
+      "keyTopics": "关键话题",
+      "keyDataPoints": "关键数据点",
+      "sourceName": "来源名称",
+      "sourceUrl": "来源链接"
+    },
+    "buttons": {
+      "cancel": "取消",
+      "save": "保存",
+      "saving": "保存中..."
+    }
+  },
   "error": {
     "fetchFailed": "获取数据失败",
+    "fetchDetailFailed": "获取市场信息详情失败",
     "reload": "重新加载",
+    "saveFailed": "保存失败",
     "title": "错误",
     "unknown": "未知错误"
   },

--- a/src/server/controller/market.ts
+++ b/src/server/controller/market.ts
@@ -17,6 +17,23 @@ const GetMarketInfoListSchema = z.object({
   limit: z.number().int().positive().optional().default(20),
 });
 
+const UpdateMarketInfoSchema = z.object({
+  id: z.number().int().positive(),
+  assetMetaIds: z.array(z.number().int().positive()).optional(),
+  title: z.string().optional(),
+  symbol: z.string().optional(),
+  sentiment: z.string().optional(),
+  importance: z.string().optional(),
+  summary: z.string().optional(),
+  keyTopics: z.string().nullable().optional(),
+  marketImpact: z.string().optional(),
+  keyDataPoints: z.string().nullable().optional(),
+  sourceUrl: z.string().nullable().optional(),
+  sourceName: z.string().nullable().optional(),
+  originalContent: z.string().nullable().optional(),
+  contentMode: z.enum(['ai_summary', 'original']).optional(),
+});
+
 const DeleteMarketInfoSchema = z.object({
   id: z.number().int().positive(),
 });
@@ -160,6 +177,31 @@ export class MarketBizController extends BaseBizController {
     } catch (error) {
       logger.error('[MarketBizController] 获取资产市场信息列表失败:', error);
       return this.error('获取资产市场信息列表失败', 'get_asset_market_infos_error');
+    }
+  }
+
+  @WithRequestContext()
+  async updateMarketInfo(body: any) {
+    try {
+      logger.info('[MarketBizController] 收到更新市场信息请求');
+
+      const parsed = { ...body, id: typeof body.id === 'string' ? parseInt(body.id) : body.id };
+      const validationResult = UpdateMarketInfoSchema.safeParse(parsed);
+      if (!validationResult.success) {
+        return this.responseValidateError(validationResult.error);
+      }
+
+      const { id, ...rest } = validationResult.data;
+
+      const updated = await assetMarketInfoService.updateAssetMarketInfo(id, rest as any);
+      if (!updated) {
+        return this.error('未找到指定的资产市场信息', 'asset_market_info_not_found_error');
+      }
+
+      return this.success({ message: '市场信息更新成功', data: updated });
+    } catch (error) {
+      logger.error('[MarketBizController] 更新市场信息失败:', error);
+      return this.error('更新市场信息失败', 'update_market_info_error');
     }
   }
 

--- a/src/server/repository/assetMarketInfoRepository.ts
+++ b/src/server/repository/assetMarketInfoRepository.ts
@@ -124,6 +124,36 @@ export class AssetMarketInfoRepository extends BaseIntRepository<AssetMarketInfo
     return marketInfo;
   }
 
+  // ============== 更新操作 ==============
+
+  /**
+   * 更新市场信息并重置关联 assetMeta
+   */
+  async updateWithRelations(
+    id: number,
+    data: Partial<CreateAssetMarketInfoData>,
+    assetMetaIds: number[],
+  ): Promise<AssetMarketInfoEntity | null> {
+    await this.update(id, data);
+
+    // 先删除旧关联
+    await (db as any)
+      .delete(assetMarketInfoToAssetMeta)
+      .where(eq(assetMarketInfoToAssetMeta.assetMarketInfoId, id));
+
+    // 插入新关联
+    if (assetMetaIds.length > 0) {
+      await (db as any).insert(assetMarketInfoToAssetMeta).values(
+        assetMetaIds.map((assetMetaId) => ({
+          assetMarketInfoId: id,
+          assetMetaId,
+        })),
+      );
+    }
+
+    return this.findById(id);
+  }
+
   // ============== 删除操作 ==============
 
   /**

--- a/src/server/service/assetMarketInfoService.ts
+++ b/src/server/service/assetMarketInfoService.ts
@@ -2,6 +2,7 @@ import {
   assetMarketInfoRepository,
   type AssetMarketInfoEntity,
   type AssetMetaDetail,
+  type CreateAssetMarketInfoData,
 } from '@server/repository/assetMarketInfoRepository';
 import { assetMetaRepository } from '@server/repository/assetMetaRepository';
 import logger from '@server/base/logger';
@@ -398,6 +399,70 @@ export class AssetMarketInfoService {
         error instanceof Error ? error.message : String(error),
       );
       return 0;
+    }
+  }
+
+  // ============== 更新操作 ==============
+
+  /**
+   * 更新 assetMarketInfo 记录
+   * @param id 记录 ID
+   * @param request 更新请求（部分字段）
+   * @returns 更新后的记录，若不存在则为 null
+   */
+  async updateAssetMarketInfo(
+    id: number,
+    request: Partial<CreateAssetMarketInfoRequest>,
+  ): Promise<AssetMarketInfoType | null> {
+    try {
+      logger.info('[AssetMarketInfoService] 开始更新资产市场信息: %d', id);
+
+      // 构造可更新的字段
+      const updateData: Partial<CreateAssetMarketInfoData> = {};
+      if (request.title !== undefined) updateData.title = request.title;
+      if (request.symbol !== undefined) updateData.symbol = request.symbol;
+      if (request.sentiment !== undefined) updateData.sentiment = request.sentiment;
+      if (request.importance !== undefined) updateData.importance = request.importance;
+      if (request.summary !== undefined) updateData.summary = request.summary;
+      if (request.keyTopics !== undefined) updateData.keyTopics = request.keyTopics ?? null;
+      if (request.marketImpact !== undefined) updateData.marketImpact = request.marketImpact;
+      if (request.keyDataPoints !== undefined) updateData.keyDataPoints = request.keyDataPoints ?? null;
+      if (request.sourceUrl !== undefined) updateData.sourceUrl = request.sourceUrl ?? null;
+      if (request.sourceName !== undefined) updateData.sourceName = request.sourceName ?? null;
+      if (request.originalContent !== undefined) updateData.originalContent = request.originalContent ?? null;
+      if (request.contentMode !== undefined) updateData.contentMode = request.contentMode;
+
+      // 如果提供了 assetMetaIds，先验证其存在
+      let assetMetaIds: number[] | undefined;
+      if (request.assetMetaIds !== undefined) {
+        const existingAssetMetas = await assetMetaRepository.findByIds(request.assetMetaIds);
+        if (existingAssetMetas.length !== request.assetMetaIds.length) {
+          throw new Error('Some AssetMetas not found');
+        }
+        assetMetaIds = request.assetMetaIds;
+      }
+
+      let updated: AssetMarketInfoEntity | null;
+      if (assetMetaIds !== undefined) {
+        updated = await assetMarketInfoRepository.updateWithRelations(id, updateData, assetMetaIds);
+      } else {
+        await assetMarketInfoRepository.update(id, updateData);
+        updated = await assetMarketInfoRepository.findById(id);
+      }
+
+      if (!updated) return null;
+
+      const relatedAssetMetaIds = await assetMarketInfoRepository.getRelatedAssetMetaIds(id);
+      const assetMetasDetails = await this.getAssetMetaDetails(relatedAssetMetaIds);
+
+      logger.info('[AssetMarketInfoService] 成功更新资产市场信息: %d', id);
+      return toAssetMarketInfoResponse(updated, relatedAssetMetaIds, assetMetasDetails);
+    } catch (error) {
+      logger.error(
+        '[AssetMarketInfoService] 更新资产市场信息失败: %s',
+        error instanceof Error ? error.message : String(error),
+      );
+      throw error;
     }
   }
 

--- a/src/server/service/marketAIService.ts
+++ b/src/server/service/marketAIService.ts
@@ -227,7 +227,7 @@ Respond with a JSON object containing a "summary" field with the summary text.`;
 {
   "title": "string - 内容的简洁标题",
   "symbol": "string - 资产标识（比如 AAPL、01810[小米]等）",
-  "sentiment": "string - 投资判断（积极、消极、中性）",
+  "sentiment": "string - 投资判断，必须是以下英文值之一：positive（积极）、negative（消极）、neutral（中性）",
   "importance": "number - 重要性评级（1-10）",
   "summary": "string - 内容的简洁摘要",
   "keyTopics": ["string"] - 关键主题或趋势数组（最多5个）,
@@ -267,9 +267,18 @@ Respond with a JSON object containing a "summary" field with the summary text.`;
       const parsedResponse = JSON.parse(response);
 
       // 验证必要的字段
+      // 将中文 sentiment 兜底映射为英文（兼容旧 prompt 或模型不遵守约定的情况）
+      const sentimentMap: Record<string, string> = {
+        积极: 'positive',
+        消极: 'negative',
+        中性: 'neutral',
+      };
+      const rawSentiment = parsedResponse.sentiment || 'neutral';
+      const normalizedSentiment = sentimentMap[rawSentiment] ?? rawSentiment;
+
       const analysisResult = {
         title: parsedResponse.title || '未提取到标题',
-        sentiment: parsedResponse.sentiment || '未知',
+        sentiment: normalizedSentiment,
         importance: parsedResponse.importance || 5,
         summary: parsedResponse.summary || '未生成摘要',
         keyTopics: Array.isArray(parsedResponse.keyTopics) ? parsedResponse.keyTopics : [],


### PR DESCRIPTION
## Summary

Add comprehensive asset market information management with AI model persistence.

## Changes

- **Remember last selected AI model**: Save selected model slug to localStorage and restore on page load (falls back to default/first available model)
- **3-step market info workflow**: Fetch content → AI analyze → save data
- **Content mode toggle**: Support both AI summary and original content preservation modes
- **Detail page**: View, edit, and manage market info with related asset badges
- **Backend**: Full CRUD APIs with pagination and date range queries

## Files Changed

- 15 files, +571/-79 lines
- Frontend components, backend service/controller/repository, i18n translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added edit capability for asset market information details with form validation and error handling.
  * Model selection now persists across sessions.
  * Chat navigation displays a pulsing badge indicator when AI is actively generating.

* **Improvements**
  * Enhanced navigation flow: returning from market info entry now routes back to the originating asset details page.
  * Sentiment normalization for consistent data handling.

* **Localization**
  * Added English and Chinese translations for new edit interface and detail views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->