### PR TITLE
feat(global-search): add asset search with Cmd+K shortcut

### DIFF
--- a/src/app/components/global-search.tsx
+++ b/src/app/components/global-search.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import * as React from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
+import { SearchIcon } from 'lucide-react';
+import {
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from '@renderer/components/ui/command';
+import { get } from '@/app/lib/request/index';
+
+interface AssetSearchResult {
+  id: string;
+  title: string;
+  description: string;
+  type: string;
+  source: string;
+}
+
+export function GlobalSearch() {
+  const { t } = useTranslation('common');
+  const router = useRouter();
+  const [open, setOpen] = React.useState(false);
+  const [query, setQuery] = React.useState('');
+  const [results, setResults] = React.useState<AssetSearchResult[]>([]);
+  const [loading, setLoading] = React.useState(false);
+
+  // Cmd+K / Ctrl+K keyboard shortcut
+  React.useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setOpen((prev) => !prev);
+      }
+    };
+    document.addEventListener('keydown', down);
+    return () => document.removeEventListener('keydown', down);
+  }, []);
+
+  // Debounced search
+  React.useEffect(() => {
+    if (!query.trim()) {
+      setResults([]);
+      return;
+    }
+
+    const timer = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const response = await get<{
+          data: { results: AssetSearchResult[] };
+        }>(`/api/search/local?query=${encodeURIComponent(query)}&pageSize=10`);
+        // Filter to only asset meta results
+        const assetResults = (response.data?.results || []).filter((r) =>
+          r.id.startsWith('meta-'),
+        );
+        setResults(assetResults);
+      } catch {
+        setResults([]);
+      } finally {
+        setLoading(false);
+      }
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  const handleSelect = (resultId: string) => {
+    const realId = resultId.replace('meta-', '');
+    setOpen(false);
+    setQuery('');
+    setResults([]);
+    router.push(`/asset-meta/${realId}`);
+  };
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+      >
+        <SearchIcon className="size-4" />
+        <span className="hidden sm:inline">{t('globalSearch.searchHint')}</span>
+        <kbd className="pointer-events-none hidden h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground sm:inline-flex">
+          <span className="text-xs">⌘</span>K
+        </kbd>
+      </button>
+      <CommandDialog
+        open={open}
+        onOpenChange={setOpen}
+        title={t('globalSearch.searchHint')}
+        description={t('globalSearch.placeholder')}
+      >
+        <CommandInput
+          placeholder={t('globalSearch.placeholder')}
+          value={query}
+          onValueChange={setQuery}
+        />
+        <CommandList>
+          {loading && (
+            <div className="py-6 text-center text-sm text-muted-foreground">
+              {t('loading')}
+            </div>
+          )}
+          {!loading && query.trim() && results.length === 0 && (
+            <CommandEmpty>{t('globalSearch.noResults')}</CommandEmpty>
+          )}
+          {results.length > 0 && (
+            <CommandGroup heading={t('globalSearch.assets')}>
+              {results.map((result) => (
+                <CommandItem
+                  key={result.id}
+                  value={result.title}
+                  onSelect={() => handleSelect(result.id)}
+                >
+                  <SearchIcon className="mr-2 size-4" />
+                  <div className="flex flex-col">
+                    <span>{result.title}</span>
+                    {result.description && (
+                      <span className="text-xs text-muted-foreground line-clamp-1">
+                        {result.description}
+                      </span>
+                    )}
+                  </div>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+        </CommandList>
+      </CommandDialog>
+    </>
+  );
+}

--- a/src/app/components/site-header.tsx
+++ b/src/app/components/site-header.tsx
@@ -7,6 +7,7 @@ import { useMemo } from 'react';
 // Import the navigation data
 import { data } from '@renderer/components/app-sidebar';
 import { useTranslation } from 'react-i18next';
+import { GlobalSearch } from '@renderer/components/global-search';
 
 /**
  * Renders the site header and displays a title derived from the current route.
@@ -64,25 +65,16 @@ export function SiteHeader() {
       <div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
         <SidebarTrigger className="-ml-1" />
         <Separator orientation="vertical" className="mx-2 data-[orientation=vertical]:h-4" />
-        <h1 className="text-base font-medium w-full" style={{
+        <h1 className="text-base font-medium flex-1" style={{
           // @ts-expect-error - WebkitAppRegion is not a standard CSS property
           WebkitAppRegion: 'drag',
           appRegion: 'drag',
           WebkitUserSelect: 'none',
           userSelect: 'none',
         }}>{getTitle}</h1>
-        {/* <div className="ml-auto flex items-center gap-2">
-          <Button variant="ghost" asChild size="sm" className="hidden sm:flex">
-            <a
-              href="https://github.com/shadcn-ui/ui/tree/main/apps/v4/app/(examples)/dashboard"
-              rel="noopener noreferrer"
-              target="_blank"
-              className="dark:text-foreground"
-            >
-              GitHub
-            </a>
-          </Button>
-        </div> */}
+        <div className="ml-auto flex items-center gap-2">
+          <GlobalSearch />
+        </div>
       </div>
     </header>
   );

--- a/src/locales/en-US/common.json
+++ b/src/locales/en-US/common.json
@@ -60,6 +60,12 @@
   "saveFailed": "Save Failed",
   "saveSuccess": "Save Success",
   "search": "Search",
+  "globalSearch": {
+    "placeholder": "Search assets...",
+    "noResults": "No assets found.",
+    "assets": "Assets",
+    "searchHint": "Search"
+  },
   "settings": "Settings",
   "share": "Share",
   "submit": "Submit",

--- a/src/locales/zh-CN/common.json
+++ b/src/locales/zh-CN/common.json
@@ -60,6 +60,12 @@
   "saveFailed": "保存失败",
   "saveSuccess": "保存成功",
   "search": "搜索",
+  "globalSearch": {
+    "placeholder": "搜索资产...",
+    "noResults": "未找到相关资产",
+    "assets": "资产",
+    "searchHint": "搜索"
+  },
   "settings": "设置",
   "share": "分享",
   "submit": "提交",


### PR DESCRIPTION
## Summary

Add a global search component to the site header for quick asset navigation. Users can open the search dialog with Cmd+K (or Ctrl+K), type a query, and jump directly to an asset's detail page.

## Changes

- **New component** `GlobalSearch` using `CommandDialog` UI with:
  - Debounced search against `/api/search/local` endpoint
  - Filtering to asset meta results only (`meta-` prefix)
  - Navigation to `/asset-meta/{id}` on selection
- **Update** `site-header` to integrate the `GlobalSearch` component
- **i18n** Add `globalSearch` keys for EN and ZH locales

## Test plan

- [ ] Open any page and press `Cmd+K` / `Ctrl+K`
- [ ] Type a stock name and verify results appear
- [ ] Select a result and confirm navigation to the correct asset page
- [ ] Verify UI strings display correctly in both EN and ZH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added global search functionality with keyboard shortcut support to discover and navigate to assets
  * Search displays results in a command-style interface with loading states and empty-state messaging
  * Integrated search component into the site header for convenient access

* **Localization**
  * Added search UI strings in English and Simplified Chinese

<!-- end of auto-generated comment: release notes by coderabbit.ai -->