### PR TITLE
fix(chat): Hermes引擎显示技能面板而非内置插件

### DIFF
--- a/src/app/(pages)/chat/features/ChatInput/ActionBar/Tools/index.tsx
+++ b/src/app/(pages)/chat/features/ChatInput/ActionBar/Tools/index.tsx
@@ -34,7 +34,7 @@ const PluginsTools = memo(() => {
 });
 
 /**
- * Claude 引擎专用工具面板：仅渲染 skills。
+ * Claude 和 Hermes 引擎工具面板：仅渲染 skills。
  * 无 loading 状态（技能切换为同步操作）。
  */
 const SkillsTools = memo(() => {
@@ -58,10 +58,13 @@ const SkillsTools = memo(() => {
 
 /**
  * 顶层 Tools 组件：根据 engineType 条件渲染对应工具面板。
+ * - Claude 和 Hermes 引擎：使用技能面板
+ * - DeepAgents 引擎：使用内置插件面板
  * 通过拆分组件确保 checkbox 状态、loading 状态完全隔离，互不干扰。
  */
 const Tools = memo(() => {
   const { t } = useTranslation('setting');
+  
   const engineType = useSessionStore((s) => {
     const session = sessionSelectors.currentSession(s);
     return session?.config?.engineType || 'deepagents';
@@ -69,7 +72,9 @@ const Tools = memo(() => {
 
   return (
     <Suspense fallback={<Action disabled icon={Blocks} title={t('tool.title')} />}>
-      {engineType === 'claude' ? <SkillsTools /> : <PluginsTools />}
+      {(engineType === 'claude' || engineType === 'hermes') 
+        ? <SkillsTools /> 
+        : <PluginsTools />}
     </Suspense>
   );
 });


### PR DESCRIPTION
**问题**\n当引擎选择为hermes时，工具面板会错误地显示「内置的插件」面板，而不是显示技能列表。\n\n**解决方案**\n修改 `Tools` 组件的条件判断，让hermes引擎与claude引擎行为一致，都显示技能面板（SkillsTools）。\n\n**改动**\n- `src/app/(pages)/chat/features/ChatInput/ActionBar/Tools/index.tsx`: 将条件从 `engineType === 'claude'` 改为 `engineType === 'claude' || engineType === 'hermes'`\n\n**测试**\n- 切换到hermes引擎时，工具面板显示技能列表 ✓\n- 切换到claude引擎时，工具面板显示技能列表 ✓\n- 切换到deepagents引擎时，工具面板显示内置插件 ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Expanded engine compatibility by improving tool selection logic for different AI engines and clarifying DeepAgents support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ishenli/investment-agent/pull/82)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->