### PR TITLE
fix(hermes): enable reflectionConfig in HermesEngine

### DIFF
--- a/src/server/core/agents/hermes/engine.ts
+++ b/src/server/core/agents/hermes/engine.ts
@@ -73,6 +73,8 @@ export class HermesEngine implements IAgentEngine {
       });
     }
 
+    const userSkillsDir = skillFileScanner.getUserSkillsRoot(userId);
+
     // 3. Build pi-ai message context
     const piMessages = messages.map((msg) => {
       if (msg.role === 'user') {
@@ -201,6 +203,20 @@ export class HermesEngine implements IAgentEngine {
         sinks: [],
         callbacks: observabilityCallbacks,
         pricing: defaultModelPricing,
+      },
+      reflectionConfig: {
+        enabled: true,
+        backgroundMode: true,
+        frameworksPath: path.join(
+          getProjectRoot(),
+          'packages/hermes-agent/src/reflection/frameworks/investment-analysis.json',
+        ),
+        localSkillsDir: userSkillsDir,
+        onSkillChanged: async (event) => {
+          await skillService.ensureSkillRecord(userId, event.slug);
+          skillRegistry.invalidate(userId);
+          await skillService.syncDeployment(userId);
+        },
       },
     });
 

--- a/src/server/core/agents/hermes/engine.ts
+++ b/src/server/core/agents/hermes/engine.ts
@@ -18,7 +18,7 @@ import { skillRegistry } from '@server/lib/skill/SkillRegistry';
 import { resolveAgentModel } from '@server/service/agentModelResolver';
 import { skillService } from '@server/service/skillService';
 import { registerBusinessTools } from '@server/core/agents/hermes';
-import { getProjectRoot } from '@server/base/env';
+import { getProjectRoot, getProjectDir } from '@server/base/env';
 import { observabilityService } from '@server/service/observabilityService';
 import { defaultModelPricing } from '@server/config/modelPricing';
 import logger from '@server/base/logger';
@@ -48,6 +48,13 @@ export class HermesEngine implements IAgentEngine {
     logger.info(`[HermesEngine] Resolved model: id=${piModel.id} api=${piModel.api} provider=${piModel.provider} baseUrl=${piModel.baseUrl} apiKey=${apiKey ? '***' : 'NONE'}`);
 
     // 2. 注册工具
+    const userSkillsDir = skillFileScanner.ensureUserSkillsRoot(userId);
+    const handleSkillChanged = async (event: { slug: string }) => {
+      await skillService.ensureSkillRecord(userId, event.slug);
+      skillRegistry.invalidate(userId);
+      await skillService.syncDeployment(userId);
+    };
+
     let registry: ToolRegistry | undefined;
     if (enableTools) {
       registry = ToolRegistry.create();
@@ -59,21 +66,14 @@ export class HermesEngine implements IAgentEngine {
       const enabledSkills = await skillRegistry.getEnabledSkills(userId);
       // Reverse so that more specific/later skill roots override earlier ones
       // in registerSkillTools (user skills > bundled skills).
-      const userSkillsDir = skillFileScanner.ensureUserSkillsRoot(userId);
       registerSkillTools(registry, {
         skillRoots: [...skillFileScanner.getSkillRoots(userSkillsDir)].reverse(),
         localSkillsDir: userSkillsDir,
         sessionId: String(userId),
         enabledSlugs: enabledSkills.map((s) => s.id),
-        onSkillChanged: async (event) => {
-          await skillService.ensureSkillRecord(userId, event.slug);
-          skillRegistry.invalidate(userId);
-          await skillService.syncDeployment(userId);
-        },
+        onSkillChanged: handleSkillChanged,
       });
     }
-
-    const userSkillsDir = skillFileScanner.getUserSkillsRoot(userId);
 
     // 3. Build pi-ai message context
     const piMessages = messages.map((msg) => {
@@ -208,15 +208,11 @@ export class HermesEngine implements IAgentEngine {
         enabled: true,
         backgroundMode: true,
         frameworksPath: path.join(
-          getProjectRoot(),
+          getProjectDir(),
           'packages/hermes-agent/src/reflection/frameworks/investment-analysis.json',
         ),
         localSkillsDir: userSkillsDir,
-        onSkillChanged: async (event) => {
-          await skillService.ensureSkillRecord(userId, event.slug);
-          skillRegistry.invalidate(userId);
-          await skillService.syncDeployment(userId);
-        },
+        onSkillChanged: handleSkillChanged,
       },
     });
 


### PR DESCRIPTION
## 问题

`HermesEngine.run()` 在创建 `HermesAgent` 时未传入 `reflectionConfig`，导致反射/自迭代子系统虽然在源码中完整存在，但从未在运行时被实例化执行。

## 修复内容

在 `HermesEngine` 中传递 `reflectionConfig`，具体配置：

| 字段 | 值 | 说明 |
|------|-----|------|
| `enabled` | `true` | 开启 reflection |
| `backgroundMode` | `true` | 后台异步执行，不阻塞主对话 |
| `frameworksPath` | `investment-analysis.json` | 审计维度框架 |
| `localSkillsDir` | `skillFileScanner.getUserSkillsRoot(userId)` | 技能写入目录 |
| `onSkillChanged` | 同步到 `skillRegistry` + `skillService` | 新生成的技能自动注册 |

## 当前仓库已有的反射基础设施（本次未改动，仅接通）

- `packages/hermes-agent/src/reflection/auditor.ts` — 框架审计器
- `packages/hermes-agent/src/reflection/background-reviewer.ts` — 后台异步 reviewer
- `packages/hermes-agent/src/reflection/skill-generator.ts` — 自动生成 SKILL.md
- `packages/hermes-agent/src/reflection/learning-recorder.ts` — 学习记录持久化
- `packages/hermes-agent/src/reflection/metrics.ts` — 反射指标统计
- `packages/hermes-agent/src/reflection/frameworks/investment-analysis.json` — 7 维度投资审计框架

## 改动范围

仅修改 `src/server/core/agents/hermes/engine.ts`，新增 16 行。

## 关联 Issue

Fixes #79


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled background reflection and analysis for the Hermes agent.
  * Automatic skill synchronization now triggers deployment updates when skills change.

* **Improvements**
  * Better handling of user-specific skill configurations.
  * Improved skill registry consistency and reliability during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->