### PR TITLE
feat: observe skill usage and improve observability UI

### DIFF
--- a/drizzle/schema/chat-observability.ts
+++ b/drizzle/schema/chat-observability.ts
@@ -7,150 +7,177 @@ import { sqliteTable, text, integer, real, index } from 'drizzle-orm/sqlite-core
 
 // ============== Extended Traces with Reflection Metrics ==============
 
-export const chatTracesExtended = sqliteTable('chat_traces_extended', {
-  id: text('id').primaryKey(),
-  sessionId: text('session_id').notNull(),
-  topicId: text('topic_id'),
-  agentName: text('agent_name').notNull(),
-  // Main trace status
-  status: text('status', { enum: ['running', 'completed', 'error'] }).notNull(),
-  // Token metrics
-  totalTokens: integer('total_tokens').notNull().default(0),
-  inputTokens: integer('input_tokens').notNull().default(0),
-  outputTokens: integer('output_tokens').notNull().default(0),
-  cachedTokens: integer('cached_tokens').notNull().default(0),
-  reasoningTokens: integer('reasoning_tokens').notNull().default(0),
-  // Cost metrics
-  totalCost: real('total_cost').notNull().default(0),
-  inputCost: real('input_cost').notNull().default(0),
-  outputCost: real('output_cost').notNull().default(0),
-  cachedCost: real('cached_cost').notNull().default(0),
-  reasoningCost: real('reasoning_cost').notNull().default(0),
-  // Latency metrics
-  latencyMs: integer('latency_ms').notNull().default(0),
-  llmLatencyMs: integer('llm_latency_ms').notNull().default(0),
-  toolLatencyMs: integer('tool_latency_ms').notNull().default(0),
-  // Call counts
-  apiCallCount: integer('api_call_count').notNull().default(0),
-  toolCallCount: integer('tool_call_count').notNull().default(0),
-  iterationCount: integer('iteration_count').notNull().default(0),
-  // Reflection metrics
-  reflectionTriggered: integer('reflection_triggered', { mode: 'boolean' }).notNull().default(false),
-  reflectionType: text('reflection_type', { enum: ['memory', 'skills', 'combined', 'none'] }),
-  reflectionSkillsCreated: integer('reflection_skills_created').notNull().default(0),
-  reflectionMemoryUpdated: integer('reflection_memory_updated', { mode: 'boolean' }),
-  reflectionLatencyMs: integer('reflection_latency_ms').notNull().default(0),
-  reflectionDimensionsChecked: integer('reflection_dimensions_checked').notNull().default(0),
-  reflectionDimensionsCovered: integer('reflection_dimensions_covered').notNull().default(0),
-  reflectionDimensionsMissing: integer('reflection_dimensions_missing').notNull().default(0),
-  // Context compression metrics
-  compressionCount: integer('compression_count').notNull().default(0),
-  tokensSavedByCompression: integer('tokens_saved_by_compression').notNull().default(0),
-  // Error info
-  error: text('error'),
-  errorStack: text('error_stack'),
-  // Metadata
-  metadata: text('metadata', { mode: 'json' }),
-  // Timestamps
-  startTime: integer('start_time', { mode: 'timestamp' }).notNull(),
-  endTime: integer('end_time', { mode: 'timestamp' }),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-}, (table) => [
-  index('idx_chat_traces_ext_session_created').on(table.sessionId, table.createdAt),
-  index('idx_chat_traces_ext_topic_id').on(table.topicId),
-  index('idx_chat_traces_ext_status').on(table.status),
-  index('idx_chat_traces_ext_reflection').on(table.reflectionTriggered),
-]);
+export const chatTracesExtended = sqliteTable(
+  'chat_traces_extended',
+  {
+    id: text('id').primaryKey(),
+    sessionId: text('session_id').notNull(),
+    topicId: text('topic_id'),
+    agentName: text('agent_name').notNull(),
+    // Main trace status
+    status: text('status', { enum: ['running', 'completed', 'error'] }).notNull(),
+    // Token metrics
+    totalTokens: integer('total_tokens').notNull().default(0),
+    inputTokens: integer('input_tokens').notNull().default(0),
+    outputTokens: integer('output_tokens').notNull().default(0),
+    cachedTokens: integer('cached_tokens').notNull().default(0),
+    reasoningTokens: integer('reasoning_tokens').notNull().default(0),
+    // Cost metrics
+    totalCost: real('total_cost').notNull().default(0),
+    inputCost: real('input_cost').notNull().default(0),
+    outputCost: real('output_cost').notNull().default(0),
+    cachedCost: real('cached_cost').notNull().default(0),
+    reasoningCost: real('reasoning_cost').notNull().default(0),
+    // Latency metrics
+    latencyMs: integer('latency_ms').notNull().default(0),
+    llmLatencyMs: integer('llm_latency_ms').notNull().default(0),
+    toolLatencyMs: integer('tool_latency_ms').notNull().default(0),
+    // Call counts
+    apiCallCount: integer('api_call_count').notNull().default(0),
+    toolCallCount: integer('tool_call_count').notNull().default(0),
+    iterationCount: integer('iteration_count').notNull().default(0),
+    // Reflection metrics
+    reflectionTriggered: integer('reflection_triggered', { mode: 'boolean' })
+      .notNull()
+      .default(false),
+    reflectionType: text('reflection_type', { enum: ['memory', 'skills', 'combined', 'none'] }),
+    reflectionSkillsCreated: integer('reflection_skills_created').notNull().default(0),
+    reflectionMemoryUpdated: integer('reflection_memory_updated', { mode: 'boolean' }),
+    reflectionLatencyMs: integer('reflection_latency_ms').notNull().default(0),
+    reflectionDimensionsChecked: integer('reflection_dimensions_checked').notNull().default(0),
+    reflectionDimensionsCovered: integer('reflection_dimensions_covered').notNull().default(0),
+    reflectionDimensionsMissing: integer('reflection_dimensions_missing').notNull().default(0),
+    // Context compression metrics
+    compressionCount: integer('compression_count').notNull().default(0),
+    tokensSavedByCompression: integer('tokens_saved_by_compression').notNull().default(0),
+    // Error info
+    error: text('error'),
+    errorStack: text('error_stack'),
+    // Metadata
+    metadata: text('metadata', { mode: 'json' }),
+    // Timestamps
+    startTime: integer('start_time', { mode: 'timestamp' }).notNull(),
+    endTime: integer('end_time', { mode: 'timestamp' }),
+    createdAt: integer('created_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer('updated_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index('idx_chat_traces_ext_session_created').on(table.sessionId, table.createdAt),
+    index('idx_chat_traces_ext_topic_id').on(table.topicId),
+    index('idx_chat_traces_ext_status').on(table.status),
+    index('idx_chat_traces_ext_reflection').on(table.reflectionTriggered),
+  ],
+);
 
 // ============== Extended Spans ==============
 
-export const chatSpansExtended = sqliteTable('chat_spans_extended', {
-  id: text('id').primaryKey(),
-  traceId: text('trace_id').notNull(),
-  parentSpanId: text('parent_span_id'),
-  name: text('name', { 
-    enum: [
-      'llm_call', 
-      'tool_call', 
-      'context_compression',
-      'reflection',
-      'background_review',
-      'background_review_audit',
-      'background_review_skill_gen'
-    ] 
-  }).notNull(),
-  kind: text('kind', { enum: ['client', 'internal'] }).notNull(),
-  status: text('status', { enum: ['ok', 'error'] }).notNull(),
-  // Hierarchical depth for tree visualization
-  depth: integer('depth').notNull().default(0),
-  // Detailed attributes
-  attributes: text('attributes', { mode: 'json' }),
-  // Events within span
-  events: text('events', { mode: 'json' }),
-  // Timing
-  startTime: integer('start_time', { mode: 'timestamp' }).notNull(),
-  endTime: integer('end_time', { mode: 'timestamp' }),
-  durationMs: integer('duration_ms'),
-  // Token usage (for LLM calls)
-  tokenInput: integer('token_input'),
-  tokenOutput: integer('token_output'),
-  tokenCached: integer('token_cached'),
-  tokenReasoning: integer('token_reasoning'),
-  // Cost
-  cost: real('cost'),
-  // Model info (for LLM calls)
-  modelName: text('model_name'),
-  // Tool info (for tool calls)
-  toolName: text('tool_name'),
-  toolCallId: text('tool_call_id'),
-  toolError: text('tool_error'),
-  // Reflection-specific
-  reflectionTrigger: text('reflection_trigger', { enum: ['memory', 'skills', 'combined'] }),
-  reflectionSkillsCreated: integer('reflection_skills_created'),
-  reflectionMemoryUpdated: integer('reflection_memory_updated', { mode: 'boolean' }),
-  // Timestamps
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-}, (table) => [
-  index('idx_chat_spans_ext_trace_id').on(table.traceId),
-  index('idx_chat_spans_ext_parent_span_id').on(table.parentSpanId),
-  index('idx_chat_spans_ext_name').on(table.name),
-  index('idx_chat_spans_ext_status').on(table.status),
-]);
+export const chatSpansExtended = sqliteTable(
+  'chat_spans_extended',
+  {
+    id: text('id').primaryKey(),
+    traceId: text('trace_id').notNull(),
+    parentSpanId: text('parent_span_id'),
+    name: text('name', {
+      enum: [
+        'llm_call',
+        'tool_call',
+        'skill_use',
+        'context_compression',
+        'reflection',
+        'background_review',
+        'background_review_audit',
+        'background_review_skill_gen',
+      ],
+    }).notNull(),
+    kind: text('kind', { enum: ['client', 'internal'] }).notNull(),
+    status: text('status', { enum: ['ok', 'error'] }).notNull(),
+    // Hierarchical depth for tree visualization
+    depth: integer('depth').notNull().default(0),
+    // Detailed attributes
+    attributes: text('attributes', { mode: 'json' }),
+    // Events within span
+    events: text('events', { mode: 'json' }),
+    // Timing
+    startTime: integer('start_time', { mode: 'timestamp' }).notNull(),
+    endTime: integer('end_time', { mode: 'timestamp' }),
+    durationMs: integer('duration_ms'),
+    // Token usage (for LLM calls)
+    tokenInput: integer('token_input'),
+    tokenOutput: integer('token_output'),
+    tokenCached: integer('token_cached'),
+    tokenReasoning: integer('token_reasoning'),
+    // Cost
+    cost: real('cost'),
+    // Model info (for LLM calls)
+    modelName: text('model_name'),
+    // Tool info (for tool calls)
+    toolName: text('tool_name'),
+    toolCallId: text('tool_call_id'),
+    toolError: text('tool_error'),
+    // Reflection-specific
+    reflectionTrigger: text('reflection_trigger', { enum: ['memory', 'skills', 'combined'] }),
+    reflectionSkillsCreated: integer('reflection_skills_created'),
+    reflectionMemoryUpdated: integer('reflection_memory_updated', { mode: 'boolean' }),
+    // Timestamps
+    createdAt: integer('created_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer('updated_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index('idx_chat_spans_ext_trace_id').on(table.traceId),
+    index('idx_chat_spans_ext_parent_span_id').on(table.parentSpanId),
+    index('idx_chat_spans_ext_name').on(table.name),
+    index('idx_chat_spans_ext_status').on(table.status),
+  ],
+);
 
 // ============== Observability Metrics View ==============
 
-export const chatObservabilityMetrics = sqliteTable('chat_observability_metrics', {
-  id: integer('id').primaryKey({ autoIncrement: true }),
-  sessionId: text('session_id'),
-  topicId: text('topic_id'),
-  agentName: text('agent_name'),
-  // Time bucket (hourly aggregation)
-  timeBucket: text('time_bucket').notNull(), // Format: YYYY-MM-DD HH:00
-  // Aggregated metrics
-  traceCount: integer('trace_count').notNull().default(0),
-  avgLatencyMs: real('avg_latency_ms').notNull().default(0),
-  maxLatencyMs: integer('max_latency_ms').notNull().default(0),
-  minLatencyMs: integer('min_latency_ms').notNull().default(0),
-  p50LatencyMs: integer('p50_latency_ms').notNull().default(0),
-  p95LatencyMs: integer('p95_latency_ms').notNull().default(0),
-  p99LatencyMs: integer('p99_latency_ms').notNull().default(0),
-  totalTokens: integer('total_tokens').notNull().default(0),
-  totalCost: real('total_cost').notNull().default(0),
-  errorCount: integer('error_count').notNull().default(0),
-  // Reflection metrics
-  reflectionCount: integer('reflection_count').notNull().default(0),
-  reflectionSkillsCreated: integer('reflection_skills_created').notNull().default(0),
-  reflectionMemoryUpdates: integer('reflection_memory_updates').notNull().default(0),
-  // Timestamps
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-}, (table) => [
-  index('idx_obs_metrics_session').on(table.sessionId, table.timeBucket),
-  index('idx_obs_metrics_agent').on(table.agentName, table.timeBucket),
-  index('idx_obs_metrics_time').on(table.timeBucket),
-]);
+export const chatObservabilityMetrics = sqliteTable(
+  'chat_observability_metrics',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    sessionId: text('session_id'),
+    topicId: text('topic_id'),
+    agentName: text('agent_name'),
+    // Time bucket (hourly aggregation)
+    timeBucket: text('time_bucket').notNull(), // Format: YYYY-MM-DD HH:00
+    // Aggregated metrics
+    traceCount: integer('trace_count').notNull().default(0),
+    avgLatencyMs: real('avg_latency_ms').notNull().default(0),
+    maxLatencyMs: integer('max_latency_ms').notNull().default(0),
+    minLatencyMs: integer('min_latency_ms').notNull().default(0),
+    p50LatencyMs: integer('p50_latency_ms').notNull().default(0),
+    p95LatencyMs: integer('p95_latency_ms').notNull().default(0),
+    p99LatencyMs: integer('p99_latency_ms').notNull().default(0),
+    totalTokens: integer('total_tokens').notNull().default(0),
+    totalCost: real('total_cost').notNull().default(0),
+    errorCount: integer('error_count').notNull().default(0),
+    // Reflection metrics
+    reflectionCount: integer('reflection_count').notNull().default(0),
+    reflectionSkillsCreated: integer('reflection_skills_created').notNull().default(0),
+    reflectionMemoryUpdates: integer('reflection_memory_updates').notNull().default(0),
+    // Timestamps
+    createdAt: integer('created_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer('updated_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index('idx_obs_metrics_session').on(table.sessionId, table.timeBucket),
+    index('idx_obs_metrics_agent').on(table.agentName, table.timeBucket),
+    index('idx_obs_metrics_time').on(table.timeBucket),
+  ],
+);
 
 // ============== Type Exports ==============
 

--- a/drizzle/schema/chat.ts
+++ b/drizzle/schema/chat.ts
@@ -17,8 +17,12 @@ export const chatSessionGroups = sqliteTable('chat_session_groups', {
   id: text('id').primaryKey(),
   name: text('name').notNull(),
   sort: integer('sort').notNull().default(0),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
+  createdAt: integer('created_at', { mode: 'timestamp' })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  updatedAt: integer('updated_at', { mode: 'timestamp' })
+    .notNull()
+    .$defaultFn(() => new Date()),
 });
 
 // ============== Sessions ==============
@@ -71,26 +75,34 @@ export type SessionMeta = {
  * 聊天会话表
  * 对应 Dexie: sessions
  */
-export const chatSessions = sqliteTable('chat_sessions', {
-  id: text('id').primaryKey(),
-  userId: integer('user_id')
-    .notNull()
-    .references(() => users.id, { onDelete: 'cascade' }),
-  slug: text('slug').notNull().unique(),
-  type: text('type', { enum: ['agent', 'group'] }).notNull(),
-  groupId: text('group_id').references(() => chatSessionGroups.id, { onDelete: 'set null' }),
-  pinned: integer('pinned', { mode: 'boolean' }).notNull().default(false),
-  config: text('config', { mode: 'json' }).notNull().$type<AgentConfig>(),
-  meta: text('meta', { mode: 'json' }).notNull().$type<SessionMeta>(),
-  agentId: text('agent_id'),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-}, (table) => [
-  index('idx_chat_sessions_user_id').on(table.userId),
-  index('idx_chat_sessions_group_id').on(table.groupId),
-  index('idx_chat_sessions_updated_at').on(table.updatedAt),
-  index('idx_chat_sessions_pinned').on(table.pinned),
-]);
+export const chatSessions = sqliteTable(
+  'chat_sessions',
+  {
+    id: text('id').primaryKey(),
+    userId: integer('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    slug: text('slug').notNull().unique(),
+    type: text('type', { enum: ['agent', 'group'] }).notNull(),
+    groupId: text('group_id').references(() => chatSessionGroups.id, { onDelete: 'set null' }),
+    pinned: integer('pinned', { mode: 'boolean' }).notNull().default(false),
+    config: text('config', { mode: 'json' }).notNull().$type<AgentConfig>(),
+    meta: text('meta', { mode: 'json' }).notNull().$type<SessionMeta>(),
+    agentId: text('agent_id'),
+    createdAt: integer('created_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer('updated_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index('idx_chat_sessions_user_id').on(table.userId),
+    index('idx_chat_sessions_group_id').on(table.groupId),
+    index('idx_chat_sessions_updated_at').on(table.updatedAt),
+    index('idx_chat_sessions_pinned').on(table.pinned),
+  ],
+);
 
 // ============== Topics ==============
 
@@ -98,19 +110,27 @@ export const chatSessions = sqliteTable('chat_sessions', {
  * 聊天话题表
  * 对应 Dexie: topics
  */
-export const chatTopics = sqliteTable('chat_topics', {
-  id: text('id').primaryKey(),
-  sessionId: text('session_id')
-    .notNull()
-    .references(() => chatSessions.id, { onDelete: 'cascade' }),
-  title: text('title').notNull(),
-  favorite: integer('favorite', { mode: 'boolean' }).notNull().default(false),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-}, (table) => [
-  index('idx_chat_topics_session_id').on(table.sessionId),
-  index('idx_chat_topics_favorite').on(table.favorite),
-]);
+export const chatTopics = sqliteTable(
+  'chat_topics',
+  {
+    id: text('id').primaryKey(),
+    sessionId: text('session_id')
+      .notNull()
+      .references(() => chatSessions.id, { onDelete: 'cascade' }),
+    title: text('title').notNull(),
+    favorite: integer('favorite', { mode: 'boolean' }).notNull().default(false),
+    createdAt: integer('created_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer('updated_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index('idx_chat_topics_session_id').on(table.sessionId),
+    index('idx_chat_topics_favorite').on(table.favorite),
+  ],
+);
 
 // ============== Messages ==============
 
@@ -150,51 +170,59 @@ export type TranslateInfo = {
  * 聊天消息表
  * 对应 Dexie: messages
  */
-export const chatMessages = sqliteTable('chat_messages', {
-  id: text('id').primaryKey(),
-  sessionId: text('session_id')
-    .notNull()
-    .references(() => chatSessions.id, { onDelete: 'cascade' }),
-  topicId: text('topic_id').references(() => chatTopics.id, { onDelete: 'cascade' }),
-  parentId: text('parent_id'),
-  role: text('role', { enum: ['user', 'system', 'assistant', 'tool'] }).notNull(),
-  content: text('content').notNull(),
-  files: text('files', { mode: 'json' }).$type<string[]>(),
-  favorite: integer('favorite').notNull().default(0),
-  userLikeTag: text('user_like_tag', { enum: ['like', 'dislike', 'unknown'] }),
-  dislikeReason: text('dislike_reason'),
-  error: text('error', { mode: 'json' }),
-  reasoning: text('reasoning', { mode: 'json' }),
-  search: text('search', { mode: 'json' }),
-  imageList: text('image_list', { mode: 'json' }),
-  metadata: text('metadata', { mode: 'json' }),
-  tools: text('tools', { mode: 'json' }).$type<ToolCall[]>(),
-  toolCallId: text('tool_call_id'),
-  plugin: text('plugin', { mode: 'json' }).$type<PluginInfo>(),
-  pluginState: text('plugin_state', { mode: 'json' }),
-  pluginError: text('plugin_error', { mode: 'json' }),
-  fromModel: text('from_model'),
-  fromProvider: text('from_provider'),
-  translate: text('translate', { mode: 'json' }).$type<TranslateInfo>(),
-  tts: text('tts', { mode: 'json' }),
-  traceId: text('trace_id'),
-  observationId: text('observation_id'),
-  quotaId: text('quota_id'),
-  model: text('model'),
-  provider: text('provider'),
-  related: text('related', { mode: 'json' }).$type<string[]>(),
-  uiArtifacts: text('ui_artifacts', { mode: 'json' }),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-}, (table) => [
-  // 复合索引用于查询会话下的话题消息
-  index('idx_chat_messages_session_topic').on(table.sessionId, table.topicId),
-  index('idx_chat_messages_parent_id').on(table.parentId),
-  index('idx_chat_messages_role').on(table.role),
-  index('idx_chat_messages_created_at').on(table.createdAt),
-  index('idx_chat_messages_trace_id').on(table.traceId),
-  index('idx_chat_messages_tool_call_id').on(table.toolCallId),
-]);
+export const chatMessages = sqliteTable(
+  'chat_messages',
+  {
+    id: text('id').primaryKey(),
+    sessionId: text('session_id')
+      .notNull()
+      .references(() => chatSessions.id, { onDelete: 'cascade' }),
+    topicId: text('topic_id').references(() => chatTopics.id, { onDelete: 'cascade' }),
+    parentId: text('parent_id'),
+    role: text('role', { enum: ['user', 'system', 'assistant', 'tool'] }).notNull(),
+    content: text('content').notNull(),
+    files: text('files', { mode: 'json' }).$type<string[]>(),
+    favorite: integer('favorite').notNull().default(0),
+    userLikeTag: text('user_like_tag', { enum: ['like', 'dislike', 'unknown'] }),
+    dislikeReason: text('dislike_reason'),
+    error: text('error', { mode: 'json' }),
+    reasoning: text('reasoning', { mode: 'json' }),
+    search: text('search', { mode: 'json' }),
+    imageList: text('image_list', { mode: 'json' }),
+    metadata: text('metadata', { mode: 'json' }),
+    tools: text('tools', { mode: 'json' }).$type<ToolCall[]>(),
+    toolCallId: text('tool_call_id'),
+    plugin: text('plugin', { mode: 'json' }).$type<PluginInfo>(),
+    pluginState: text('plugin_state', { mode: 'json' }),
+    pluginError: text('plugin_error', { mode: 'json' }),
+    fromModel: text('from_model'),
+    fromProvider: text('from_provider'),
+    translate: text('translate', { mode: 'json' }).$type<TranslateInfo>(),
+    tts: text('tts', { mode: 'json' }),
+    traceId: text('trace_id'),
+    observationId: text('observation_id'),
+    quotaId: text('quota_id'),
+    model: text('model'),
+    provider: text('provider'),
+    related: text('related', { mode: 'json' }).$type<string[]>(),
+    uiArtifacts: text('ui_artifacts', { mode: 'json' }),
+    createdAt: integer('created_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer('updated_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    // 复合索引用于查询会话下的话题消息
+    index('idx_chat_messages_session_topic').on(table.sessionId, table.topicId),
+    index('idx_chat_messages_parent_id').on(table.parentId),
+    index('idx_chat_messages_role').on(table.role),
+    index('idx_chat_messages_created_at').on(table.createdAt),
+    index('idx_chat_messages_trace_id').on(table.traceId),
+    index('idx_chat_messages_tool_call_id').on(table.toolCallId),
+  ],
+);
 
 // ============== Threads ==============
 
@@ -203,32 +231,44 @@ export const chatMessages = sqliteTable('chat_messages', {
  * 对应 Dexie: threads
  */
 // @ts-expect-error - Self-referencing table causes TypeScript inference issues
-export const chatThreads = sqliteTable('chat_threads', {
-  id: text('id').primaryKey(),
-  topicId: text('topic_id')
-    .notNull()
-    .references(() => chatTopics.id, { onDelete: 'cascade' }),
-  sourceMessageId: text('source_message_id')
-    .notNull()
-    .references(() => chatMessages.id, { onDelete: 'cascade' }),
-  // @ts-expect-error - Self-referencing causes TypeScript inference issue
-  parentThreadId: text('parent_thread_id').references(() => chatThreads.id, { onDelete: 'set null' }),
-  title: text('title'),
-  type: text('type', { enum: ['continuation', 'standalone'] }).notNull(),
-  status: text('status', { enum: ['active', 'deprecated', 'archived'] }).notNull().default('active'),
-  clientId: text('client_id'),
-  userId: text('user_id'),
-  lastActiveAt: integer('last_active_at', { mode: 'timestamp' }),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-}, (table) => [
-  index('idx_chat_threads_topic_id').on(table.topicId),
-  index('idx_chat_threads_source_message_id').on(table.sourceMessageId),
-  index('idx_chat_threads_parent_thread_id').on(table.parentThreadId),
-  index('idx_chat_threads_status').on(table.status),
-  // 复合索引用于查找话题下特定消息的线程
-  index('idx_chat_threads_topic_source').on(table.topicId, table.sourceMessageId),
-]);
+export const chatThreads = sqliteTable(
+  'chat_threads',
+  {
+    id: text('id').primaryKey(),
+    topicId: text('topic_id')
+      .notNull()
+      .references(() => chatTopics.id, { onDelete: 'cascade' }),
+    sourceMessageId: text('source_message_id')
+      .notNull()
+      .references(() => chatMessages.id, { onDelete: 'cascade' }),
+    // @ts-expect-error - Self-referencing causes TypeScript inference issue
+    parentThreadId: text('parent_thread_id').references(() => chatThreads.id, {
+      onDelete: 'set null',
+    }),
+    title: text('title'),
+    type: text('type', { enum: ['continuation', 'standalone'] }).notNull(),
+    status: text('status', { enum: ['active', 'deprecated', 'archived'] })
+      .notNull()
+      .default('active'),
+    clientId: text('client_id'),
+    userId: text('user_id'),
+    lastActiveAt: integer('last_active_at', { mode: 'timestamp' }),
+    createdAt: integer('created_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer('updated_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index('idx_chat_threads_topic_id').on(table.topicId),
+    index('idx_chat_threads_source_message_id').on(table.sourceMessageId),
+    index('idx_chat_threads_parent_thread_id').on(table.parentThreadId),
+    index('idx_chat_threads_status').on(table.status),
+    // 复合索引用于查找话题下特定消息的线程
+    index('idx_chat_threads_topic_source').on(table.topicId, table.sourceMessageId),
+  ],
+);
 
 // ============== Files ==============
 
@@ -236,23 +276,31 @@ export const chatThreads = sqliteTable('chat_threads', {
  * 聊天文件附件表
  * 对应 Dexie: files
  */
-export const chatFiles = sqliteTable('chat_files', {
-  id: text('id').primaryKey(),
-  messageId: text('message_id').references(() => chatMessages.id, { onDelete: 'set null' }),
-  sessionId: text('session_id').references(() => chatSessions.id, { onDelete: 'cascade' }),
-  name: text('name').notNull(),
-  fileType: text('file_type').notNull(),
-  size: integer('size').notNull(),
-  saveMode: text('save_mode', { enum: ['local', 'url'] }).notNull(),
-  url: text('url'),
-  data: text('data'), // Base64 encoded for small files
-  metadata: text('metadata', { mode: 'json' }),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-}, (table) => [
-  index('idx_chat_files_message_id').on(table.messageId),
-  index('idx_chat_files_session_id').on(table.sessionId),
-]);
+export const chatFiles = sqliteTable(
+  'chat_files',
+  {
+    id: text('id').primaryKey(),
+    messageId: text('message_id').references(() => chatMessages.id, { onDelete: 'set null' }),
+    sessionId: text('session_id').references(() => chatSessions.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    fileType: text('file_type').notNull(),
+    size: integer('size').notNull(),
+    saveMode: text('save_mode', { enum: ['local', 'url'] }).notNull(),
+    url: text('url'),
+    data: text('data'), // Base64 encoded for small files
+    metadata: text('metadata', { mode: 'json' }),
+    createdAt: integer('created_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer('updated_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index('idx_chat_files_message_id').on(table.messageId),
+    index('idx_chat_files_session_id').on(table.sessionId),
+  ],
+);
 
 // ============== Plugins ==============
 
@@ -273,66 +321,90 @@ export type PluginManifest = {
  * 聊天插件表
  * 对应 Dexie: plugins
  */
-export const chatPlugins = sqliteTable('chat_plugins', {
-  id: text('id').primaryKey(),
-  identifier: text('identifier').notNull().unique(),
-  type: text('type', { enum: ['plugin', 'customPlugin'] }).notNull(),
-  manifest: text('manifest', { mode: 'json' }).$type<PluginManifest>(),
-  settings: text('settings', { mode: 'json' }),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-}, (table) => [
-  index('idx_chat_plugins_type').on(table.type),
-]);
+export const chatPlugins = sqliteTable(
+  'chat_plugins',
+  {
+    id: text('id').primaryKey(),
+    identifier: text('identifier').notNull().unique(),
+    type: text('type', { enum: ['plugin', 'customPlugin'] }).notNull(),
+    manifest: text('manifest', { mode: 'json' }).$type<PluginManifest>(),
+    settings: text('settings', { mode: 'json' }),
+    createdAt: integer('created_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer('updated_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [index('idx_chat_plugins_type').on(table.type)],
+);
 
 // ============== Observability: Traces ==============
 
-export const chatTraces = sqliteTable('chat_traces', {
-  id: text('id').primaryKey(),
-  sessionId: text('session_id').notNull(),
-  topicId: text('topic_id'),
-  agentName: text('agent_name').notNull(),
-  status: text('status', { enum: ['running', 'completed', 'error'] }).notNull(),
-  totalTokens: integer('total_tokens').notNull().default(0),
-  inputTokens: integer('input_tokens').notNull().default(0),
-  outputTokens: integer('output_tokens').notNull().default(0),
-  totalCost: real('total_cost').notNull().default(0),
-  inputCost: real('input_cost').notNull().default(0),
-  outputCost: real('output_cost').notNull().default(0),
-  latencyMs: integer('latency_ms').notNull().default(0),
-  toolCallCount: integer('tool_call_count').notNull().default(0),
-  error: text('error'),
-  metadata: text('metadata', { mode: 'json' }),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-}, (table) => [
-  index('idx_chat_traces_session_created').on(table.sessionId, table.createdAt),
-  index('idx_chat_traces_topic_id').on(table.topicId),
-]);
+export const chatTraces = sqliteTable(
+  'chat_traces',
+  {
+    id: text('id').primaryKey(),
+    sessionId: text('session_id').notNull(),
+    topicId: text('topic_id'),
+    agentName: text('agent_name').notNull(),
+    status: text('status', { enum: ['running', 'completed', 'error'] }).notNull(),
+    totalTokens: integer('total_tokens').notNull().default(0),
+    inputTokens: integer('input_tokens').notNull().default(0),
+    outputTokens: integer('output_tokens').notNull().default(0),
+    totalCost: real('total_cost').notNull().default(0),
+    inputCost: real('input_cost').notNull().default(0),
+    outputCost: real('output_cost').notNull().default(0),
+    latencyMs: integer('latency_ms').notNull().default(0),
+    toolCallCount: integer('tool_call_count').notNull().default(0),
+    error: text('error'),
+    metadata: text('metadata', { mode: 'json' }),
+    createdAt: integer('created_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer('updated_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index('idx_chat_traces_session_created').on(table.sessionId, table.createdAt),
+    index('idx_chat_traces_topic_id').on(table.topicId),
+  ],
+);
 
 // ============== Observability: Spans ==============
 
-export const chatSpans = sqliteTable('chat_spans', {
-  id: text('id').primaryKey(),
-  traceId: text('trace_id').notNull(),
-  parentSpanId: text('parent_span_id'),
-  name: text('name', { enum: ['llm_call', 'tool_call', 'context_compression'] }).notNull(),
-  kind: text('kind', { enum: ['client', 'internal'] }).notNull(),
-  status: text('status', { enum: ['ok', 'error'] }).notNull(),
-  attributes: text('attributes', { mode: 'json' }),
-  events: text('events', { mode: 'json' }),
-  startTime: integer('start_time', { mode: 'timestamp' }).notNull(),
-  endTime: integer('end_time', { mode: 'timestamp' }),
-  durationMs: integer('duration_ms'),
-  tokenInput: integer('token_input'),
-  tokenOutput: integer('token_output'),
-  cost: real('cost'),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-}, (table) => [
-  index('idx_chat_spans_trace_id').on(table.traceId),
-  index('idx_chat_spans_parent_span_id').on(table.parentSpanId),
-]);
+export const chatSpans = sqliteTable(
+  'chat_spans',
+  {
+    id: text('id').primaryKey(),
+    traceId: text('trace_id').notNull(),
+    parentSpanId: text('parent_span_id'),
+    name: text('name', {
+      enum: ['llm_call', 'tool_call', 'skill_use', 'context_compression'],
+    }).notNull(),
+    kind: text('kind', { enum: ['client', 'internal'] }).notNull(),
+    status: text('status', { enum: ['ok', 'error'] }).notNull(),
+    attributes: text('attributes', { mode: 'json' }),
+    events: text('events', { mode: 'json' }),
+    startTime: integer('start_time', { mode: 'timestamp' }).notNull(),
+    endTime: integer('end_time', { mode: 'timestamp' }),
+    durationMs: integer('duration_ms'),
+    tokenInput: integer('token_input'),
+    tokenOutput: integer('token_output'),
+    cost: real('cost'),
+    createdAt: integer('created_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer('updated_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index('idx_chat_spans_trace_id').on(table.traceId),
+    index('idx_chat_spans_parent_span_id').on(table.parentSpanId),
+  ],
+);
 
 // ============== Type Exports ==============
 
@@ -383,4 +455,5 @@ export type NewChatPlugin = typeof chatPlugins.$inferInsert;
 export type ChatTrace = typeof chatTraces.$inferSelect;
 export type NewChatTrace = typeof chatTraces.$inferInsert;
 export type ChatSpan = typeof chatSpans.$inferSelect;
-export type NewChatSpan = typeof chatSpans.$inferInsert;export * from "./chat-observability";
+export type NewChatSpan = typeof chatSpans.$inferInsert;
+export * from './chat-observability';

--- a/packages/hermes-agent/src/__tests__/loop.test.ts
+++ b/packages/hermes-agent/src/__tests__/loop.test.ts
@@ -249,4 +249,50 @@ describe('runAgentLoop memory lifecycle', () => {
       }),
     );
   });
+
+  it('records skills_list as skill_use span with category as skillName', async () => {
+    const context = makeContext('List available skills');
+    mockComplete
+      .mockResolvedValueOnce(makeToolCallAssistant('skills_list', { category: 'investing' }) as any)
+      .mockResolvedValueOnce(makeAssistant('Done') as any);
+
+    baseConfig.toolExecutor = vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text: '## Investing Skills\n- macro-analysis\n- portfolio' }],
+      isError: false,
+    });
+
+    const tracer = {
+      startSpan: vi.fn((traceCtx, name, kind, attributes) => ({
+        id: `span-${name}`,
+        traceId: traceCtx.traceId,
+        name,
+        kind,
+        status: 'ok',
+        startTime: Date.now(),
+        events: [],
+        attributes,
+      })),
+      endSpan: vi.fn((span, options) => ({ ...span, ...options })),
+      addEvent: vi.fn(),
+    };
+
+    await runAgentLoop(
+      baseConfig,
+      context,
+      { traceId: 'tr-test', agentName: 'test-agent', startTime: Date.now() },
+      tracer as any,
+    );
+
+    expect(tracer.startSpan).toHaveBeenCalledWith(
+      expect.any(Object),
+      'skill_use',
+      'internal',
+      expect.objectContaining({
+        tool: 'skills_list',
+        skillTool: true,
+        skillAction: 'list',
+        skillName: 'investing',
+      }),
+    );
+  });
 });

--- a/packages/hermes-agent/src/__tests__/loop.test.ts
+++ b/packages/hermes-agent/src/__tests__/loop.test.ts
@@ -19,10 +19,10 @@ function makeAssistant(text: string) {
   };
 }
 
-function makeToolCallAssistant(toolName: string) {
+function makeToolCallAssistant(toolName: string, args: Record<string, unknown> = {}) {
   return {
     role: 'assistant' as const,
-    content: [{ type: 'toolCall' as const, name: toolName, arguments: {}, id: 'tc-1' }],
+    content: [{ type: 'toolCall' as const, name: toolName, arguments: args, id: 'tc-1' }],
     timestamp: Date.now(),
   };
 }
@@ -116,10 +116,7 @@ describe('runAgentLoop memory lifecycle', () => {
 
     const res = await runAgentLoop(baseConfig, context);
     expect(res.completed).toBe(true);
-    expect(console.warn).toHaveBeenCalledWith(
-      '[AgentLoop] Memory sync failed:',
-      expect.any(Error),
-    );
+    expect(console.warn).toHaveBeenCalledWith('[AgentLoop] Memory sync failed:', expect.any(Error));
   });
 
   it('strips stale ephemeral memory-context before injecting new one', async () => {
@@ -139,7 +136,10 @@ describe('runAgentLoop memory lifecycle', () => {
 
     await runAgentLoop(baseConfig, context);
     const memoryBlocks = context.messages.filter(
-      (m) => m.role === 'user' && typeof m.content === 'string' && m.content.startsWith('<memory-context>'),
+      (m) =>
+        m.role === 'user' &&
+        typeof m.content === 'string' &&
+        m.content.startsWith('<memory-context>'),
     );
     expect(memoryBlocks).toHaveLength(1);
     expect(memoryBlocks[0].content).toContain('prefetched');
@@ -191,5 +191,62 @@ describe('runAgentLoop memory lifecycle', () => {
     await runAgentLoop(baseConfig, context);
     expect(stream).toHaveBeenCalled();
     expect(complete).not.toHaveBeenCalled();
+  });
+
+  it('records skill tools as skill_use spans', async () => {
+    const context = makeContext('Use a relevant skill');
+    mockComplete
+      .mockResolvedValueOnce(makeToolCallAssistant('skill_view', { name: 'macro-analysis' }) as any)
+      .mockResolvedValueOnce(makeAssistant('Done') as any);
+
+    baseConfig.toolExecutor = vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text: '# Skill: Macro Analysis' }],
+      isError: false,
+    });
+
+    const tracer = {
+      startSpan: vi.fn((traceCtx, name, kind, attributes) => ({
+        id: `span-${name}`,
+        traceId: traceCtx.traceId,
+        name,
+        kind,
+        status: 'ok',
+        startTime: Date.now(),
+        events: [],
+        attributes,
+      })),
+      endSpan: vi.fn((span, options) => ({ ...span, ...options })),
+      addEvent: vi.fn(),
+    };
+
+    await runAgentLoop(
+      baseConfig,
+      context,
+      { traceId: 'tr-test', agentName: 'test-agent', startTime: Date.now() },
+      tracer as any,
+    );
+
+    expect(tracer.startSpan).toHaveBeenCalledWith(
+      expect.any(Object),
+      'skill_use',
+      'internal',
+      expect.objectContaining({
+        tool: 'skill_view',
+        skillTool: true,
+        skillAction: 'view',
+        skillName: 'macro-analysis',
+      }),
+    );
+    expect(tracer.endSpan).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'skill_use' }),
+      expect.objectContaining({
+        status: 'ok',
+        attributes: expect.objectContaining({
+          skillAction: 'view',
+          skillName: 'macro-analysis',
+          resultSummary: '# Skill: Macro Analysis',
+        }),
+      }),
+    );
   });
 });

--- a/packages/hermes-agent/src/agent.ts
+++ b/packages/hermes-agent/src/agent.ts
@@ -205,7 +205,16 @@ export class HermesAgent {
       ? new CostTracker(this.config.observability.pricing, this.config.observability.defaultPricing)
       : undefined;
 
-    const traceCtx = this.tracer?.startTrace(this.config.name ?? 'hermes');
+    const inputText = typeof input === 'string'
+      ? input
+      : typeof input.message === 'string'
+        ? input.message
+        : typeof input.message.content === 'string'
+          ? input.message.content
+          : '';
+    const traceCtx = this.tracer?.startTrace(this.config.name ?? 'hermes', {
+      metadata: { input: inputText.slice(0, 200) },
+    });
 
     const agentConfig: AgentConfig = {
       name: this.config.name ?? 'hermes',

--- a/packages/hermes-agent/src/index.ts
+++ b/packages/hermes-agent/src/index.ts
@@ -148,6 +148,7 @@ export type {
   ObservabilitySink,
   LogLevel,
   SinkConfig,
+  SpanName,
 } from './observability';
 
 // ============== Permission System ==============

--- a/packages/hermes-agent/src/loop.ts
+++ b/packages/hermes-agent/src/loop.ts
@@ -28,12 +28,7 @@ import { defaultContentGuard } from './guard/content-validator';
 import { defaultAuditLogger } from './guard/audit-logger';
 import { ContextCompressor } from './context';
 import { buildMemoryContextBlock } from './memory-manager';
-import type {
-  AgentConfig,
-  AgentCallbacks,
-  HermesAgentResult,
-  ToolExecutor,
-} from './types';
+import type { AgentConfig, AgentCallbacks, HermesAgentResult, ToolExecutor } from './types';
 import { ToolRegistry } from './tools';
 import type { TraceContext, Tracer, MetricsCollector, CostTracker } from './observability';
 
@@ -67,17 +62,40 @@ export async function runAgentLoop(
     if (!text) return '';
     return text.length > maxLen ? text.slice(0, maxLen) + '...' : text;
   };
-  
+
+  const skillToolActions: Record<string, string> = {
+    skills_list: 'list',
+    skill_view: 'view',
+    skill_manage: 'manage',
+  };
+
+  const buildSkillAttributes = (toolCall: ToolCall): Record<string, unknown> => {
+    const skillName =
+      toolCall.name === 'skills_list' ? toolCall.arguments.category : toolCall.arguments.name;
+
+    return {
+      tool: toolCall.name,
+      skillTool: true,
+      skillAction: skillToolActions[toolCall.name],
+      ...(skillName ? { skillName: String(skillName) } : {}),
+      ...(toolCall.arguments.file_path
+        ? { skillFilePath: String(toolCall.arguments.file_path) }
+        : {}),
+    };
+  };
+
   // Helper: extract full prompt from context messages
   const extractFullPrompt = (messages: Context['messages']): string => {
-    return messages.map(m => {
-      if (typeof m.content === 'string') return `[${m.role}]: ${m.content}`;
-      if (Array.isArray(m.content)) {
-        const textParts = m.content.filter((b: any) => b.type === 'text').map((b: any) => b.text);
-        return `[${m.role}]: ${textParts.join(' ')}`;
-      }
-      return `[${m.role}]: [non-text content]`;
-    }).join('\n\n');
+    return messages
+      .map((m) => {
+        if (typeof m.content === 'string') return `[${m.role}]: ${m.content}`;
+        if (Array.isArray(m.content)) {
+          const textParts = m.content.filter((b: any) => b.type === 'text').map((b: any) => b.text);
+          return `[${m.role}]: ${textParts.join(' ')}`;
+        }
+        return `[${m.role}]: [non-text content]`;
+      })
+      .join('\n\n');
   };
 
   // Extract abort signal from streamOptions for cancellation checks
@@ -102,7 +120,12 @@ export async function runAgentLoop(
       memoryManager.onTurnStart(turnNumber, originalUserContent);
       // Strip any existing ephemeral memory-context blocks before injecting the new one.
       context.messages = context.messages.filter(
-        (m) => !(m.role === 'user' && typeof m.content === 'string' && m.content.startsWith('<memory-context>')),
+        (m) =>
+          !(
+            m.role === 'user' &&
+            typeof m.content === 'string' &&
+            m.content.startsWith('<memory-context>')
+          ),
       );
       if (signal?.aborted) {
         console.warn('[AgentLoop] Memory prefetch skipped: aborted');
@@ -114,22 +137,26 @@ export async function runAgentLoop(
           `Memory prefetch timed out after ${prefetchTimeoutMs}ms`,
         );
         if (prefetch?.trim()) {
-        // Find the last user message by content (more robust than reference equality)
-        let lastUserIndex = -1;
-        for (let i = context.messages.length - 1; i >= 0; i--) {
-          const m = context.messages[i];
-          if (m.role === 'user' && typeof m.content === 'string' && m.content === originalUserContent) {
-            lastUserIndex = i;
-            break;
+          // Find the last user message by content (more robust than reference equality)
+          let lastUserIndex = -1;
+          for (let i = context.messages.length - 1; i >= 0; i--) {
+            const m = context.messages[i];
+            if (
+              m.role === 'user' &&
+              typeof m.content === 'string' &&
+              m.content === originalUserContent
+            ) {
+              lastUserIndex = i;
+              break;
+            }
           }
-        }
-        if (lastUserIndex >= 0) {
-          context.messages.splice(lastUserIndex, 0, {
-            role: 'user',
-            content: buildMemoryContextBlock(prefetch),
-            timestamp: Date.now(),
-          });
-        }
+          if (lastUserIndex >= 0) {
+            context.messages.splice(lastUserIndex, 0, {
+              role: 'user',
+              content: buildMemoryContextBlock(prefetch),
+              timestamp: Date.now(),
+            });
+          }
         }
       }
     } catch (e) {
@@ -168,7 +195,10 @@ export async function runAgentLoop(
 
     // Call LLM with retry (instrumented)
     let response: AssistantMessage;
-    const llmSpan = traceCtx && tracer ? tracer.startSpan(traceCtx, 'llm_call', 'client', { model: model.name }) : undefined;
+    const llmSpan =
+      traceCtx && tracer
+        ? tracer.startSpan(traceCtx, 'llm_call', 'client', { model: model.name })
+        : undefined;
     const llmStartTime = Date.now();
 
     try {
@@ -214,11 +244,15 @@ export async function runAgentLoop(
     // Record LLM usage and cost
     if (response.usage) {
       if (traceCtx && metrics) {
-        metrics.recordTokens(traceCtx, {
-          input: response.usage.input,
-          output: response.usage.output,
-          total: response.usage.totalTokens,
-        }, model.name);
+        metrics.recordTokens(
+          traceCtx,
+          {
+            input: response.usage.input,
+            output: response.usage.output,
+            total: response.usage.totalTokens,
+          },
+          model.name,
+        );
         metrics.recordLlmLatency(traceCtx, llmDurationMs, model.name);
       }
       if (traceCtx && costTracker && response.usage.totalTokens) {
@@ -270,12 +304,11 @@ export async function runAgentLoop(
       const tokensBefore = response.usage.input;
       compressor.updateFromResponse(response.usage);
       if (compressor.shouldCompress()) {
-        const compressionSpan = traceCtx && tracer ? tracer.startSpan(traceCtx, 'context_compression', 'internal') : undefined;
-        context.messages = await compressor.compress(
-          context.messages,
-          model,
-          response.usage.input,
-        );
+        const compressionSpan =
+          traceCtx && tracer
+            ? tracer.startSpan(traceCtx, 'context_compression', 'internal')
+            : undefined;
+        context.messages = await compressor.compress(context.messages, model, response.usage.input);
         const tokensAfter = estimateMessageTokens(context.messages);
         if (traceCtx && metrics) {
           metrics.recordCompression(traceCtx, tokensBefore, tokensAfter);
@@ -337,9 +370,9 @@ export async function runAgentLoop(
       toolCalls.map((tc) => tc.name),
     );
 
-   // Permission configuration (constant per turn)
+    // Permission configuration (constant per turn)
     const permissionLevel = config.permissionLevel ?? 'auto';
-   const CONFIRMATION_TIMEOUT_MS = 60_000;
+    const CONFIRMATION_TIMEOUT_MS = 60_000;
 
     // Execute tool calls
     for (const toolCall of toolCalls) {
@@ -366,7 +399,10 @@ export async function runAgentLoop(
         permissionLevel,
         policy,
         decision: policy === 'deny' ? 'denied' : 'allowed',
-        reason: policy === 'deny' ? `Permission level ${permissionLevel} denies ${toolCategory} operations` : undefined,
+        reason:
+          policy === 'deny'
+            ? `Permission level ${permissionLevel} denies ${toolCategory} operations`
+            : undefined,
       });
 
       if (policy === 'deny') {
@@ -415,12 +451,24 @@ export async function runAgentLoop(
             reason: 'Confirmation timeout or error',
           });
 
-          context.messages.push(buildBlockedResult(toolCall, `Confirmation timeout for "${toolCall.name}". Operation cancelled.`, callbacks));
+          context.messages.push(
+            buildBlockedResult(
+              toolCall,
+              `Confirmation timeout for "${toolCall.name}". Operation cancelled.`,
+              callbacks,
+            ),
+          );
           continue;
         }
 
         if (!confirmed) {
-          context.messages.push(buildBlockedResult(toolCall, `User declined execution of "${toolCall.name}".`, callbacks));
+          context.messages.push(
+            buildBlockedResult(
+              toolCall,
+              `User declined execution of "${toolCall.name}".`,
+              callbacks,
+            ),
+          );
           continue;
         }
       }
@@ -435,10 +483,21 @@ export async function runAgentLoop(
           );
           if (!guardDecision.allowed) {
             defaultAuditLogger.log({
-              toolName: toolCall.name, toolCategory, permissionLevel, policy,
-              decision: 'denied', reason: guardDecision.reason, contentGuardPattern: guardDecision.pattern,
+              toolName: toolCall.name,
+              toolCategory,
+              permissionLevel,
+              policy,
+              decision: 'denied',
+              reason: guardDecision.reason,
+              contentGuardPattern: guardDecision.pattern,
             });
-            context.messages.push(buildBlockedResult(toolCall, `Content guard blocked: ${guardDecision.reason}`, callbacks));
+            context.messages.push(
+              buildBlockedResult(
+                toolCall,
+                `Content guard blocked: ${guardDecision.reason}`,
+                callbacks,
+              ),
+            );
             continue;
           }
         }
@@ -446,15 +505,27 @@ export async function runAgentLoop(
 
       // Content Guard: validate write-category tools for sensitive file paths
       if (toolCategory === 'write') {
-        const filePath = toolCall.arguments.filePath ?? toolCall.arguments.file_path ?? toolCall.arguments.path;
+        const filePath =
+          toolCall.arguments.filePath ?? toolCall.arguments.file_path ?? toolCall.arguments.path;
         if (filePath) {
           const guardDecision = defaultContentGuard.validateFilePath(String(filePath));
           if (!guardDecision.allowed) {
             defaultAuditLogger.log({
-              toolName: toolCall.name, toolCategory, permissionLevel, policy,
-              decision: 'denied', reason: guardDecision.reason, contentGuardPattern: guardDecision.pattern,
+              toolName: toolCall.name,
+              toolCategory,
+              permissionLevel,
+              policy,
+              decision: 'denied',
+              reason: guardDecision.reason,
+              contentGuardPattern: guardDecision.pattern,
             });
-            context.messages.push(buildBlockedResult(toolCall, `Content guard blocked: ${guardDecision.reason}`, callbacks));
+            context.messages.push(
+              buildBlockedResult(
+                toolCall,
+                `Content guard blocked: ${guardDecision.reason}`,
+                callbacks,
+              ),
+            );
             continue;
           }
         }
@@ -462,7 +533,16 @@ export async function runAgentLoop(
 
       // ============== Execute Tool ==============
       let resultMessage: ToolResultMessage;
-      const toolSpan = traceCtx && tracer ? tracer.startSpan(traceCtx, 'tool_call', 'internal', { tool: toolCall.name }) : undefined;
+      const isSkillTool = toolCall.name in skillToolActions;
+      const toolSpan =
+        traceCtx && tracer
+          ? tracer.startSpan(
+              traceCtx,
+              isSkillTool ? 'skill_use' : 'tool_call',
+              'internal',
+              isSkillTool ? buildSkillAttributes(toolCall) : { tool: toolCall.name },
+            )
+          : undefined;
       const toolStartTime = Date.now();
 
       if (toolExecutor) {
@@ -496,7 +576,7 @@ export async function runAgentLoop(
           tracer.endSpan(toolSpan, {
             status: result.isError ? 'error' : 'ok',
             attributes: {
-              tool: toolCall.name,
+              ...(isSkillTool ? buildSkillAttributes(toolCall) : { tool: toolCall.name }),
               args: summarize(JSON.stringify(toolCall.arguments)),
               argsFull: JSON.stringify(toolCall.arguments, null, 2),
               isError: result.isError,
@@ -525,7 +605,7 @@ export async function runAgentLoop(
           tracer.endSpan(toolSpan, {
             status: 'error',
             attributes: {
-              tool: toolCall.name,
+              ...(isSkillTool ? buildSkillAttributes(toolCall) : { tool: toolCall.name }),
               args: summarize(JSON.stringify(toolCall.arguments)),
               argsFull: JSON.stringify(toolCall.arguments, null, 2),
               error: 'no executor',
@@ -599,10 +679,7 @@ async function streamWithCallbacks(
     if (event.type === 'text_delta') {
       callbacks.onTextDelta?.(event.delta);
     } else if (event.type === 'error') {
-      throw new HermesAgentError(
-        event.error.errorMessage ?? 'Stream error',
-        'API_ERROR',
-      );
+      throw new HermesAgentError(event.error.errorMessage ?? 'Stream error', 'API_ERROR');
     }
   }
 
@@ -614,9 +691,7 @@ async function streamWithCallbacks(
  */
 function extractText(message: AssistantMessage): string {
   return message.content
-    .filter((block): block is Extract<typeof block, { type: 'text' }> =>
-      block.type === 'text',
-    )
+    .filter((block): block is Extract<typeof block, { type: 'text' }> => block.type === 'text')
     .map((block) => block.text)
     .join('');
 }

--- a/packages/hermes-agent/src/loop.ts
+++ b/packages/hermes-agent/src/loop.ts
@@ -32,6 +32,27 @@ import type { AgentConfig, AgentCallbacks, HermesAgentResult, ToolExecutor } fro
 import { ToolRegistry } from './tools';
 import type { TraceContext, Tracer, MetricsCollector, CostTracker } from './observability';
 
+const skillToolActions: Record<string, string> = {
+  skills_list: 'list',
+  skill_view: 'view',
+  skill_manage: 'manage',
+};
+
+const buildSkillAttributes = (toolCall: ToolCall): Record<string, unknown> => {
+  const skillName =
+    toolCall.name === 'skills_list' ? toolCall.arguments.category : toolCall.arguments.name;
+
+  return {
+    tool: toolCall.name,
+    skillTool: true,
+    skillAction: skillToolActions[toolCall.name],
+    ...(skillName ? { skillName: String(skillName) } : {}),
+    ...(toolCall.arguments.file_path
+      ? { skillFilePath: String(toolCall.arguments.file_path) }
+      : {}),
+  };
+};
+
 /**
  * Run the agent loop: call LLM → execute tools → repeat until done.
  */
@@ -61,27 +82,6 @@ export async function runAgentLoop(
   const summarize = (text: string, maxLen = 250): string => {
     if (!text) return '';
     return text.length > maxLen ? text.slice(0, maxLen) + '...' : text;
-  };
-
-  const skillToolActions: Record<string, string> = {
-    skills_list: 'list',
-    skill_view: 'view',
-    skill_manage: 'manage',
-  };
-
-  const buildSkillAttributes = (toolCall: ToolCall): Record<string, unknown> => {
-    const skillName =
-      toolCall.name === 'skills_list' ? toolCall.arguments.category : toolCall.arguments.name;
-
-    return {
-      tool: toolCall.name,
-      skillTool: true,
-      skillAction: skillToolActions[toolCall.name],
-      ...(skillName ? { skillName: String(skillName) } : {}),
-      ...(toolCall.arguments.file_path
-        ? { skillFilePath: String(toolCall.arguments.file_path) }
-        : {}),
-    };
   };
 
   // Helper: extract full prompt from context messages

--- a/packages/hermes-agent/src/observability/types.ts
+++ b/packages/hermes-agent/src/observability/types.ts
@@ -29,10 +29,11 @@ export interface ObservabilitySink {
 // ============== Trace / Span Model ==============
 
 /** Valid span names */
-export type SpanName = 
-  | 'llm_call' 
-  | 'tool_call' 
-  | 'context_compression' 
+export type SpanName =
+  | 'llm_call'
+  | 'tool_call'
+  | 'skill_use'
+  | 'context_compression'
   | 'reflection'
   | 'background_review'
   | 'background_review_audit'
@@ -279,7 +280,13 @@ export interface ObservabilityEvent {
   traceId: string;
   spanId?: string;
   type: 'trace_start' | 'span_start' | 'span_end' | 'trace_end' | 'metric' | 'log';
-  payload: TraceStartEvent | SpanStartEvent | SpanEndEvent | TraceEndEvent | MetricEvent | Record<string, unknown>;
+  payload:
+    | TraceStartEvent
+    | SpanStartEvent
+    | SpanEndEvent
+    | TraceEndEvent
+    | MetricEvent
+    | Record<string, unknown>;
 }
 
 // ============== Trace Context (explicit passing) ==============

--- a/src/app/(pages)/chat/components/ObservabilityPanel/SpanDetail.tsx
+++ b/src/app/(pages)/chat/components/ObservabilityPanel/SpanDetail.tsx
@@ -4,7 +4,7 @@ import React, { memo } from 'react';
 import { Tag, Badge, Divider } from 'antd';
 import { Flexbox } from 'react-layout-kit';
 import { createStyles } from 'antd-style';
-import { MessageSquare, FileSearch, Cpu, Clock, Coins, Hash } from 'lucide-react';
+import { BookOpen, MessageSquare, FileSearch, Cpu, Clock, Coins, Hash } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { SpanData } from '@renderer/store/observability/store';
 
@@ -103,18 +103,22 @@ function formatDuration(ms?: number): string {
   return `${m}m${s}s`;
 }
 
-const InfoCard = memo<{ icon: React.ReactNode; label: string; value: string }>(({ icon, label, value }) => {
-  const { styles } = useStyles();
-  return (
-    <div className={styles.infoCard}>
-      <span className={styles.infoIcon}>{icon}</span>
-      <div style={{ minWidth: 0 }}>
-        <div className={styles.infoLabel}>{label}</div>
-        <div className={styles.infoValue} title={value}>{value}</div>
+const InfoCard = memo<{ icon: React.ReactNode; label: string; value: string }>(
+  ({ icon, label, value }) => {
+    const { styles } = useStyles();
+    return (
+      <div className={styles.infoCard}>
+        <span className={styles.infoIcon}>{icon}</span>
+        <div style={{ minWidth: 0 }}>
+          <div className={styles.infoLabel}>{label}</div>
+          <div className={styles.infoValue} title={value}>
+            {value}
+          </div>
+        </div>
       </div>
-    </div>
-  );
-});
+    );
+  },
+);
 InfoCard.displayName = 'InfoCard';
 
 const LLMCallDetail = memo<{ span: SpanData }>(({ span }) => {
@@ -135,18 +139,44 @@ const LLMCallDetail = memo<{ span: SpanData }>(({ span }) => {
         <Tag>{span.kind}</Tag>
         <Badge
           color={span.status === 'ok' ? 'green' : 'red'}
-          text={span.status === 'ok' ? t('observability.status.success') : t('observability.status.error')}
+          text={
+            span.status === 'ok'
+              ? t('observability.status.success')
+              : t('observability.status.error')
+          }
         />
       </div>
 
       <div className={styles.cardGrid}>
-        {model && <InfoCard icon={<Hash size={14} />} label={t('observability.model')} value={model} />}
-        <InfoCard icon={<Clock size={14} />} label={t('observability.duration')} value={formatDuration(span.durationMs)} />
-        <InfoCard icon={<Hash size={14} />} label={t('observability.inputTokens')} value={span.tokenInput?.toLocaleString() ?? '-'} />
-        <InfoCard icon={<Hash size={14} />} label={t('observability.outputTokens')} value={span.tokenOutput?.toLocaleString() ?? '-'} />
-        <InfoCard icon={<Coins size={14} />} label={t('observability.cost')} value={span.cost !== undefined ? `$${span.cost.toFixed(6)}` : '-'} />
+        {model && (
+          <InfoCard icon={<Hash size={14} />} label={t('observability.model')} value={model} />
+        )}
+        <InfoCard
+          icon={<Clock size={14} />}
+          label={t('observability.duration')}
+          value={formatDuration(span.durationMs)}
+        />
+        <InfoCard
+          icon={<Hash size={14} />}
+          label={t('observability.inputTokens')}
+          value={span.tokenInput?.toLocaleString() ?? '-'}
+        />
+        <InfoCard
+          icon={<Hash size={14} />}
+          label={t('observability.outputTokens')}
+          value={span.tokenOutput?.toLocaleString() ?? '-'}
+        />
+        <InfoCard
+          icon={<Coins size={14} />}
+          label={t('observability.cost')}
+          value={span.cost !== undefined ? `$${span.cost.toFixed(6)}` : '-'}
+        />
         {messageCount !== undefined && (
-          <InfoCard icon={<Hash size={14} />} label={t('observability.messages')} value={String(messageCount)} />
+          <InfoCard
+            icon={<Hash size={14} />}
+            label={t('observability.messages')}
+            value={String(messageCount)}
+          />
         )}
       </div>
 
@@ -198,21 +228,43 @@ const ToolCallDetail = memo<{ span: SpanData }>(({ span }) => {
         <Tag>{span.kind}</Tag>
         <Badge
           color={span.status === 'ok' ? 'green' : 'red'}
-          text={span.status === 'ok' ? t('observability.status.success') : t('observability.status.error')}
+          text={
+            span.status === 'ok'
+              ? t('observability.status.success')
+              : t('observability.status.error')
+          }
         />
       </div>
 
       <div className={styles.cardGrid}>
-        {toolName && <InfoCard icon={<Hash size={14} />} label={t('observability.tool')} value={toolName} />}
-        <InfoCard icon={<Clock size={14} />} label={t('observability.duration')} value={formatDuration(span.durationMs)} />
+        {toolName && (
+          <InfoCard icon={<Hash size={14} />} label={t('observability.tool')} value={toolName} />
+        )}
+        <InfoCard
+          icon={<Clock size={14} />}
+          label={t('observability.duration')}
+          value={formatDuration(span.durationMs)}
+        />
         {span.tokenInput !== undefined && (
-          <InfoCard icon={<Hash size={14} />} label={t('observability.inputTokens')} value={span.tokenInput.toLocaleString()} />
+          <InfoCard
+            icon={<Hash size={14} />}
+            label={t('observability.inputTokens')}
+            value={span.tokenInput.toLocaleString()}
+          />
         )}
         {span.tokenOutput !== undefined && (
-          <InfoCard icon={<Hash size={14} />} label={t('observability.outputTokens')} value={span.tokenOutput.toLocaleString()} />
+          <InfoCard
+            icon={<Hash size={14} />}
+            label={t('observability.outputTokens')}
+            value={span.tokenOutput.toLocaleString()}
+          />
         )}
         {span.cost !== undefined && (
-          <InfoCard icon={<Coins size={14} />} label={t('observability.cost')} value={`$${span.cost.toFixed(6)}`} />
+          <InfoCard
+            icon={<Coins size={14} />}
+            label={t('observability.cost')}
+            value={`$${span.cost.toFixed(6)}`}
+          />
         )}
       </div>
 
@@ -228,7 +280,10 @@ const ToolCallDetail = memo<{ span: SpanData }>(({ span }) => {
       {(resultFull || resultSummary) && (
         <>
           <div className={styles.sectionTitle}>{t('observability.result')}</div>
-          <div className={styles.ioBlock} style={{ borderLeftColor: isError ? '#ff4d4f' : '#52c41a' }}>
+          <div
+            className={styles.ioBlock}
+            style={{ borderLeftColor: isError ? '#ff4d4f' : '#52c41a' }}
+          >
             <pre className={styles.ioContent}>{resultFull || resultSummary}</pre>
           </div>
         </>
@@ -237,8 +292,13 @@ const ToolCallDetail = memo<{ span: SpanData }>(({ span }) => {
       {error && (
         <>
           <div className={styles.sectionTitle}>{t('observability.status.error')}</div>
-          <div className={styles.ioBlock} style={{ borderLeftColor: '#ff4d4f', background: '#fff2f0' }}>
-            <pre className={styles.ioContent} style={{ color: '#cf1322' }}>{error}</pre>
+          <div
+            className={styles.ioBlock}
+            style={{ borderLeftColor: '#ff4d4f', background: '#fff2f0' }}
+          >
+            <pre className={styles.ioContent} style={{ color: '#cf1322' }}>
+              {error}
+            </pre>
           </div>
         </>
       )}
@@ -253,6 +313,94 @@ const ToolCallDetail = memo<{ span: SpanData }>(({ span }) => {
   );
 });
 ToolCallDetail.displayName = 'ToolCallDetail';
+
+const SkillUseDetail = memo<{ span: SpanData }>(({ span }) => {
+  const { styles } = useStyles();
+  const { t } = useTranslation('chat');
+  const skillName = span.attributes?.skillName as string | undefined;
+  const skillAction = span.attributes?.skillAction as string | undefined;
+  const skillFilePath = span.attributes?.skillFilePath as string | undefined;
+  const toolName = span.attributes?.tool as string | undefined;
+  const isError = span.attributes?.isError as boolean | undefined;
+  const argsFull = span.attributes?.argsFull as string | undefined;
+  const resultSummary = span.attributes?.resultSummary as string | undefined;
+  const resultFull = span.attributes?.resultFull as string | undefined;
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.header}>
+        <BookOpen size={16} style={{ color: '#13c2c2' }} />
+        <span className={styles.title}>{t('observability.span.skillUse')}</span>
+        <Tag>{span.kind}</Tag>
+        <Badge
+          color={span.status === 'ok' ? 'green' : 'red'}
+          text={
+            span.status === 'ok'
+              ? t('observability.status.success')
+              : t('observability.status.error')
+          }
+        />
+      </div>
+
+      <div className={styles.cardGrid}>
+        {skillName && (
+          <InfoCard icon={<Hash size={14} />} label={t('observability.skill')} value={skillName} />
+        )}
+        {skillAction && (
+          <InfoCard
+            icon={<Hash size={14} />}
+            label={t('observability.action')}
+            value={skillAction}
+          />
+        )}
+        {skillFilePath && (
+          <InfoCard
+            icon={<Hash size={14} />}
+            label={t('observability.file')}
+            value={skillFilePath}
+          />
+        )}
+        {toolName && (
+          <InfoCard icon={<Hash size={14} />} label={t('observability.tool')} value={toolName} />
+        )}
+        <InfoCard
+          icon={<Clock size={14} />}
+          label={t('observability.duration')}
+          value={formatDuration(span.durationMs)}
+        />
+      </div>
+
+      {argsFull && (
+        <>
+          <div className={styles.sectionTitle}>{t('observability.arguments')}</div>
+          <div className={styles.ioBlock}>
+            <pre className={styles.ioContent}>{argsFull}</pre>
+          </div>
+        </>
+      )}
+
+      {(resultFull || resultSummary) && (
+        <>
+          <div className={styles.sectionTitle}>{t('observability.result')}</div>
+          <div
+            className={styles.ioBlock}
+            style={{ borderLeftColor: isError ? '#ff4d4f' : '#13c2c2' }}
+          >
+            <pre className={styles.ioContent}>{resultFull || resultSummary}</pre>
+          </div>
+        </>
+      )}
+
+      <Divider style={{ margin: '12px 0' }} />
+
+      <div className={styles.sectionTitle}>{t('observability.rawAttributes')}</div>
+      <div className={styles.attrBlock}>
+        <pre style={{ margin: 0, fontSize: 11 }}>{JSON.stringify(span.attributes, null, 2)}</pre>
+      </div>
+    </div>
+  );
+});
+SkillUseDetail.displayName = 'SkillUseDetail';
 
 const ContextCompressionDetail = memo<{ span: SpanData }>(({ span }) => {
   const { styles } = useStyles();
@@ -272,18 +420,38 @@ const ContextCompressionDetail = memo<{ span: SpanData }>(({ span }) => {
       </div>
 
       <div className={styles.cardGrid}>
-        <InfoCard icon={<Clock size={14} />} label={t('observability.duration')} value={formatDuration(span.durationMs)} />
+        <InfoCard
+          icon={<Clock size={14} />}
+          label={t('observability.duration')}
+          value={formatDuration(span.durationMs)}
+        />
         {tokensBefore !== undefined && (
-          <InfoCard icon={<Hash size={14} />} label={t('observability.tokensBefore')} value={tokensBefore.toLocaleString()} />
+          <InfoCard
+            icon={<Hash size={14} />}
+            label={t('observability.tokensBefore')}
+            value={tokensBefore.toLocaleString()}
+          />
         )}
         {tokensAfter !== undefined && (
-          <InfoCard icon={<Hash size={14} />} label={t('observability.tokensAfter')} value={tokensAfter.toLocaleString()} />
+          <InfoCard
+            icon={<Hash size={14} />}
+            label={t('observability.tokensAfter')}
+            value={tokensAfter.toLocaleString()}
+          />
         )}
         {saved !== undefined && (
-          <InfoCard icon={<Hash size={14} />} label={t('observability.saved')} value={`${saved.toLocaleString()}${savedPct ? ` (${savedPct}%)` : ''}`} />
+          <InfoCard
+            icon={<Hash size={14} />}
+            label={t('observability.saved')}
+            value={`${saved.toLocaleString()}${savedPct ? ` (${savedPct}%)` : ''}`}
+          />
         )}
         {span.cost !== undefined && (
-          <InfoCard icon={<Coins size={14} />} label={t('observability.cost')} value={`$${span.cost.toFixed(6)}`} />
+          <InfoCard
+            icon={<Coins size={14} />}
+            label={t('observability.cost')}
+            value={`$${span.cost.toFixed(6)}`}
+          />
         )}
       </div>
 
@@ -306,6 +474,8 @@ const SpanDetail = memo<SpanDetailProps>(({ span }) => {
       return <LLMCallDetail span={span} />;
     case 'tool_call':
       return <ToolCallDetail span={span} />;
+    case 'skill_use':
+      return <SkillUseDetail span={span} />;
     case 'context_compression':
       return <ContextCompressionDetail span={span} />;
     default:

--- a/src/app/(pages)/chat/components/ObservabilityPanel/TraceTimeline.tsx
+++ b/src/app/(pages)/chat/components/ObservabilityPanel/TraceTimeline.tsx
@@ -20,6 +20,10 @@ const SPAN_COLORS: Record<SpanData['name'], { bar: string; bg: string; light: st
   tool_call: { bar: '#52c41a', bg: '#f6ffed', light: '#d9f7be' },
   skill_use: { bar: '#13c2c2', bg: '#e6fffb', light: '#b5f5ec' },
   context_compression: { bar: '#fa8c16', bg: '#fff7e6', light: '#ffe7ba' },
+  reflection: { bar: '#722ed1', bg: '#f9f0ff', light: '#efdbff' },
+  background_review: { bar: '#eb2f96', bg: '#fff0f6', light: '#ffd6e7' },
+  background_review_audit: { bar: '#eb2f96', bg: '#fff0f6', light: '#ffd6e7' },
+  background_review_skill_gen: { bar: '#eb2f96', bg: '#fff0f6', light: '#ffd6e7' },
 };
 
 const useStyles = createStyles(({ css, token }) => ({

--- a/src/app/(pages)/chat/components/ObservabilityPanel/TraceTimeline.tsx
+++ b/src/app/(pages)/chat/components/ObservabilityPanel/TraceTimeline.tsx
@@ -3,13 +3,22 @@
 import React, { memo, useState } from 'react';
 import { Flexbox } from 'react-layout-kit';
 import { createStyles } from 'antd-style';
-import { ChevronDown, ChevronRight, Cpu, FileSearch, MessageSquare, Zap } from 'lucide-react';
+import {
+  BookOpen,
+  ChevronDown,
+  ChevronRight,
+  Cpu,
+  FileSearch,
+  MessageSquare,
+  Zap,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { SpanData } from '@renderer/store/observability/store';
 
 const SPAN_COLORS: Record<SpanData['name'], { bar: string; bg: string; light: string }> = {
   llm_call: { bar: '#1677ff', bg: '#e6f4ff', light: '#bae0ff' },
   tool_call: { bar: '#52c41a', bg: '#f6ffed', light: '#d9f7be' },
+  skill_use: { bar: '#13c2c2', bg: '#e6fffb', light: '#b5f5ec' },
   context_compression: { bar: '#fa8c16', bg: '#fff7e6', light: '#ffe7ba' },
 };
 
@@ -155,6 +164,8 @@ const SpanIcon = memo<{ name: SpanData['name'] }>(({ name }) => {
       return <MessageSquare className="w-3.5 h-3.5" style={{ color: SPAN_COLORS.llm_call.bar }} />;
     case 'tool_call':
       return <FileSearch className="w-3.5 h-3.5" style={{ color: SPAN_COLORS.tool_call.bar }} />;
+    case 'skill_use':
+      return <BookOpen className="w-3.5 h-3.5" style={{ color: SPAN_COLORS.skill_use.bar }} />;
     case 'context_compression':
       return <Cpu className="w-3.5 h-3.5" style={{ color: SPAN_COLORS.context_compression.bar }} />;
     default:
@@ -191,6 +202,11 @@ const SpanRow = memo<{
     if (s.name === 'tool_call' && s.attributes?.tool) {
       return String(s.attributes.tool);
     }
+    if (s.name === 'skill_use') {
+      return String(
+        s.attributes?.skillName ?? s.attributes?.skillAction ?? s.attributes?.tool ?? '',
+      );
+    }
     if (s.name === 'context_compression') {
       const saved = s.attributes?.saved;
       if (typeof saved === 'number') return `${saved} ${t('observability.tokensShort')}`;
@@ -203,16 +219,16 @@ const SpanRow = memo<{
 
   const startOffset = totalDuration > 0 ? ((span.startTime - traceStart) / totalDuration) * 100 : 0;
   const barWidth =
-    totalDuration > 0 && span.durationMs
-      ? Math.max(2, (span.durationMs / totalDuration) * 100)
-      : 2;
+    totalDuration > 0 && span.durationMs ? Math.max(2, (span.durationMs / totalDuration) * 100) : 2;
 
   const displayName =
     span.name === 'llm_call'
       ? t('observability.span.llmCall')
       : span.name === 'tool_call'
         ? t('observability.span.toolCall')
-        : t('observability.span.contextCompression');
+        : span.name === 'skill_use'
+          ? t('observability.span.skillUse')
+          : t('observability.span.contextCompression');
 
   return (
     <div>
@@ -225,7 +241,11 @@ const SpanRow = memo<{
         <div style={{ width: depth * 16, flexShrink: 0 }} />
         <div className={styles.indent}>
           {hasChildren ? (
-            expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />
+            expanded ? (
+              <ChevronDown size={14} />
+            ) : (
+              <ChevronRight size={14} />
+            )
           ) : (
             <span style={{ width: 14, display: 'inline-block' }} />
           )}
@@ -267,7 +287,10 @@ const SpanRow = memo<{
             </span>
           )}
 
-          <span className={cx(styles.meta, span.status === 'ok' ? styles.ok : styles.error)} style={{ minWidth: 14, textAlign: 'center' }}>
+          <span
+            className={cx(styles.meta, span.status === 'ok' ? styles.ok : styles.error)}
+            style={{ minWidth: 14, textAlign: 'center' }}
+          >
             {span.status === 'ok' ? '✓' : '✗'}
           </span>
         </div>

--- a/src/app/(pages)/setting/observability/TraceDetail.tsx
+++ b/src/app/(pages)/setting/observability/TraceDetail.tsx
@@ -35,6 +35,7 @@ export interface Trace {
   latencyMs: number;
   toolCallCount: number;
   error: string | null;
+  input: string | null;
   metadata: Record<string, unknown> | null;
   createdAt: string;
   updatedAt: string;
@@ -674,24 +675,19 @@ const SpanRow = memo<{
             />
           </div>
 
-          {span.durationMs != null && (
-            <span className="text-[11px] text-muted-foreground w-12 text-right tabular-nums">
-              {formatDuration(span.durationMs)}
-            </span>
-          )}
+          <span className="text-[11px] text-muted-foreground w-12 text-right tabular-nums">
+            {span.durationMs != null ? formatDuration(span.durationMs) : ''}
+          </span>
 
-          {(span.tokenInput != null || span.tokenOutput != null) && (
-            <span className="text-[11px] text-muted-foreground w-16 text-right tabular-nums">
-              {(span.tokenInput ?? 0) + (span.tokenOutput ?? 0)}{' '}
-              {t('observability.tokensShort', 'tk')}
-            </span>
-          )}
+          <span className="text-[11px] text-muted-foreground w-16 text-right tabular-nums">
+            {span.tokenInput != null || span.tokenOutput != null
+              ? `${(span.tokenInput ?? 0) + (span.tokenOutput ?? 0)} ${t('observability.tokensShort', 'tok')}`
+              : ''}
+          </span>
 
-          {span.cost != null && span.cost > 0 && (
-            <span className="text-[11px] text-muted-foreground w-14 text-right tabular-nums">
-              ${span.cost.toFixed(4)}
-            </span>
-          )}
+          <span className="text-[11px] text-muted-foreground w-14 text-right tabular-nums">
+            {span.cost != null && span.cost > 0 ? `$${span.cost.toFixed(4)}` : ''}
+          </span>
 
           <span
             className={`text-[11px] w-4 text-center font-semibold ${
@@ -740,14 +736,14 @@ export default function TraceDetailView({ trace, spans, stats, loading }: TraceD
 
   if (loading) {
     return (
-      <div className="mt-2 ml-8 p-6 rounded-lg bg-muted/50 flex items-center justify-center">
+      <div className="p-6 rounded-lg bg-muted/50 flex items-center justify-center">
         <div className="animate-spin h-6 w-6 border-2 border-primary border-t-transparent rounded-full" />
       </div>
     );
   }
 
   return (
-    <div className="mt-2 ml-8 p-4 rounded-lg bg-muted/50 space-y-4">
+    <div className="p-4 rounded-lg bg-muted/50 space-y-4">
       {/* Trace Overview Grid */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
         <div className="flex flex-col gap-0.5">

--- a/src/app/(pages)/setting/observability/TraceDetail.tsx
+++ b/src/app/(pages)/setting/observability/TraceDetail.tsx
@@ -7,6 +7,7 @@ import { Separator } from '@renderer/components/ui/separator';
 import {
   MessageSquare,
   FileSearch,
+  BookOpen,
   Cpu,
   Zap,
   Clock,
@@ -66,6 +67,7 @@ export interface SpanStats {
 const SPAN_COLORS: Record<string, { bar: string; text: string }> = {
   llm_call: { bar: 'bg-blue-500', text: 'text-blue-500' },
   tool_call: { bar: 'bg-green-500', text: 'text-green-500' },
+  skill_use: { bar: 'bg-teal-500', text: 'text-teal-500' },
   context_compression: { bar: 'bg-orange-500', text: 'text-orange-500' },
 };
 
@@ -114,6 +116,11 @@ function getSpanLabel(span: Span, t: any): string | null {
   if (span.name === 'tool_call' && span.attributes?.tool) {
     return String(span.attributes.tool);
   }
+  if (span.name === 'skill_use') {
+    return String(
+      span.attributes?.skillName ?? span.attributes?.skillAction ?? span.attributes?.tool ?? '',
+    );
+  }
   if (span.name === 'context_compression') {
     const saved = span.attributes?.saved;
     if (typeof saved === 'number') return `${saved} ${t('observability.tokensShort', 'tokens')}`;
@@ -124,7 +131,9 @@ function getSpanLabel(span: Span, t: any): string | null {
 function getDisplayName(name: string, t: any): string {
   if (name === 'llm_call') return t('observability.span.llmCall', 'LLM Call');
   if (name === 'tool_call') return t('observability.span.toolCall', 'Tool Call');
-  if (name === 'context_compression') return t('observability.span.contextCompression', 'Context Compression');
+  if (name === 'skill_use') return t('observability.span.skillUse', 'Skill Use');
+  if (name === 'context_compression')
+    return t('observability.span.contextCompression', 'Context Compression');
   return name;
 }
 
@@ -135,6 +144,8 @@ const SpanIcon = memo<{ name: string }>(({ name }) => {
       return <MessageSquare className="w-3.5 h-3.5 text-blue-500" />;
     case 'tool_call':
       return <FileSearch className="w-3.5 h-3.5 text-green-500" />;
+    case 'skill_use':
+      return <BookOpen className="w-3.5 h-3.5 text-teal-500" />;
     case 'context_compression':
       return <Cpu className="w-3.5 h-3.5 text-orange-500" />;
     default:
@@ -143,17 +154,21 @@ const SpanIcon = memo<{ name: string }>(({ name }) => {
 });
 SpanIcon.displayName = 'SpanIcon';
 
-const InfoCard = memo<{ icon: React.ReactNode; label: string; value: string }>(({ icon, label, value }) => {
-  return (
-    <div className="flex items-center gap-2 p-2.5 rounded-md bg-muted/60">
-      <span className="w-4 h-4 opacity-60 flex-shrink-0">{icon}</span>
-      <div className="min-w-0 overflow-hidden">
-        <div className="text-[11px] text-muted-foreground whitespace-nowrap">{label}</div>
-        <div className="text-[13px] font-medium truncate" title={value}>{value}</div>
+const InfoCard = memo<{ icon: React.ReactNode; label: string; value: string }>(
+  ({ icon, label, value }) => {
+    return (
+      <div className="flex items-center gap-2 p-2.5 rounded-md bg-muted/60">
+        <span className="w-4 h-4 opacity-60 flex-shrink-0">{icon}</span>
+        <div className="min-w-0 overflow-hidden">
+          <div className="text-[11px] text-muted-foreground whitespace-nowrap">{label}</div>
+          <div className="text-[13px] font-medium truncate" title={value}>
+            {value}
+          </div>
+        </div>
       </div>
-    </div>
-  );
-});
+    );
+  },
+);
 InfoCard.displayName = 'InfoCard';
 
 const LLMCallDetail = memo<{ span: Span }>(({ span }) => {
@@ -170,47 +185,84 @@ const LLMCallDetail = memo<{ span: Span }>(({ span }) => {
       <div className="flex items-center gap-2 mb-1">
         <MessageSquare className="w-4 h-4 text-blue-500" />
         <span className="text-sm font-semibold">{t('observability.span.llmCall', 'LLM Call')}</span>
-        <Badge variant="outline" className="text-xs">{span.kind}</Badge>
-        <Badge
-          className="text-xs"
-          variant={span.status === 'ok' ? 'default' : 'destructive'}
-        >
-          {span.status === 'ok' ? t('observability.status.success', 'Success') : t('observability.status.error', 'Error')}
+        <Badge variant="outline" className="text-xs">
+          {span.kind}
+        </Badge>
+        <Badge className="text-xs" variant={span.status === 'ok' ? 'default' : 'destructive'}>
+          {span.status === 'ok'
+            ? t('observability.status.success', 'Success')
+            : t('observability.status.error', 'Error')}
         </Badge>
       </div>
 
       <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
-        {model && <InfoCard icon={<Hash className="w-4 h-4" />} label={t('observability.model', 'Model')} value={model} />}
-        <InfoCard icon={<Clock className="w-4 h-4" />} label={t('observability.duration', 'Duration')} value={formatDuration(span.durationMs)} />
-        <InfoCard icon={<Hash className="w-4 h-4" />} label={t('observability.inputTokens', 'Input Tokens')} value={formatTokens(span.tokenInput)} />
-        <InfoCard icon={<Hash className="w-4 h-4" />} label={t('observability.outputTokens', 'Output Tokens')} value={formatTokens(span.tokenOutput)} />
-        <InfoCard icon={<Coins className="w-4 h-4" />} label={t('observability.cost', 'Cost')} value={span.cost != null ? `$${span.cost.toFixed(6)}` : '-'} />
+        {model && (
+          <InfoCard
+            icon={<Hash className="w-4 h-4" />}
+            label={t('observability.model', 'Model')}
+            value={model}
+          />
+        )}
+        <InfoCard
+          icon={<Clock className="w-4 h-4" />}
+          label={t('observability.duration', 'Duration')}
+          value={formatDuration(span.durationMs)}
+        />
+        <InfoCard
+          icon={<Hash className="w-4 h-4" />}
+          label={t('observability.inputTokens', 'Input Tokens')}
+          value={formatTokens(span.tokenInput)}
+        />
+        <InfoCard
+          icon={<Hash className="w-4 h-4" />}
+          label={t('observability.outputTokens', 'Output Tokens')}
+          value={formatTokens(span.tokenOutput)}
+        />
+        <InfoCard
+          icon={<Coins className="w-4 h-4" />}
+          label={t('observability.cost', 'Cost')}
+          value={span.cost != null ? `$${span.cost.toFixed(6)}` : '-'}
+        />
         {messageCount !== undefined && (
-          <InfoCard icon={<Hash className="w-4 h-4" />} label={t('observability.messages', 'Messages')} value={String(messageCount)} />
+          <InfoCard
+            icon={<Hash className="w-4 h-4" />}
+            label={t('observability.messages', 'Messages')}
+            value={String(messageCount)}
+          />
         )}
       </div>
 
       {(fullPrompt || promptSummary) && (
         <>
-          <div className="text-xs font-medium text-muted-foreground mt-2">{t('observability.inputPrompt', 'Input Prompt')}</div>
+          <div className="text-xs font-medium text-muted-foreground mt-2">
+            {t('observability.inputPrompt', 'Input Prompt')}
+          </div>
           <div className="border-l-2 border-primary bg-muted/30 rounded-r-md p-3">
-            <pre className="text-xs leading-relaxed whitespace-pre-wrap break-words overflow-y-auto max-h-40 font-mono">{fullPrompt || promptSummary}</pre>
+            <pre className="text-xs leading-relaxed whitespace-pre-wrap break-words overflow-y-auto max-h-40 font-mono">
+              {fullPrompt || promptSummary}
+            </pre>
           </div>
         </>
       )}
 
       {(fullResponse || responseSummary) && (
         <>
-          <div className="text-xs font-medium text-muted-foreground mt-2">{t('observability.output', 'Output')}</div>
+          <div className="text-xs font-medium text-muted-foreground mt-2">
+            {t('observability.output', 'Output')}
+          </div>
           <div className="border-l-2 border-green-500 bg-muted/30 rounded-r-md p-3">
-            <pre className="text-xs leading-relaxed whitespace-pre-wrap break-words overflow-y-auto max-h-40 font-mono">{fullResponse || responseSummary}</pre>
+            <pre className="text-xs leading-relaxed whitespace-pre-wrap break-words overflow-y-auto max-h-40 font-mono">
+              {fullResponse || responseSummary}
+            </pre>
           </div>
         </>
       )}
 
       <Separator className="my-2" />
 
-      <div className="text-xs font-medium text-muted-foreground">{t('observability.rawAttributes', 'Raw Attributes')}</div>
+      <div className="text-xs font-medium text-muted-foreground">
+        {t('observability.rawAttributes', 'Raw Attributes')}
+      </div>
       <div className="bg-muted/60 rounded-md p-3 overflow-x-auto">
         <pre className="text-[11px] font-mono">{JSON.stringify(span.attributes, null, 2)}</pre>
       </div>
@@ -233,39 +285,80 @@ const ToolCallDetail = memo<{ span: Span }>(({ span }) => {
     <div className="space-y-3">
       <div className="flex items-center gap-2 mb-1">
         <FileSearch className="w-4 h-4 text-green-500" />
-        <span className="text-sm font-semibold">{t('observability.span.toolCall', 'Tool Call')}</span>
-        <Badge variant="outline" className="text-xs">{span.kind}</Badge>
-        <Badge
-          className="text-xs"
-          variant={span.status === 'ok' ? 'default' : 'destructive'}
-        >
-          {span.status === 'ok' ? t('observability.status.success', 'Success') : t('observability.status.error', 'Error')}
+        <span className="text-sm font-semibold">
+          {t('observability.span.toolCall', 'Tool Call')}
+        </span>
+        <Badge variant="outline" className="text-xs">
+          {span.kind}
+        </Badge>
+        <Badge className="text-xs" variant={span.status === 'ok' ? 'default' : 'destructive'}>
+          {span.status === 'ok'
+            ? t('observability.status.success', 'Success')
+            : t('observability.status.error', 'Error')}
         </Badge>
       </div>
 
       <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
-        {toolName && <InfoCard icon={<Hash className="w-4 h-4" />} label={t('observability.tool', 'Tool')} value={toolName} />}
-        <InfoCard icon={<Clock className="w-4 h-4" />} label={t('observability.duration', 'Duration')} value={formatDuration(span.durationMs)} />
-        {span.tokenInput !== null && <InfoCard icon={<Hash className="w-4 h-4" />} label={t('observability.inputTokens', 'Input Tokens')} value={formatTokens(span.tokenInput)} />}
-        {span.tokenOutput !== null && <InfoCard icon={<Hash className="w-4 h-4" />} label={t('observability.outputTokens', 'Output Tokens')} value={formatTokens(span.tokenOutput)} />}
-        {span.cost !== null && <InfoCard icon={<Coins className="w-4 h-4" />} label={t('observability.cost', 'Cost')} value={`$${span.cost.toFixed(6)}`} />}
+        {toolName && (
+          <InfoCard
+            icon={<Hash className="w-4 h-4" />}
+            label={t('observability.tool', 'Tool')}
+            value={toolName}
+          />
+        )}
+        <InfoCard
+          icon={<Clock className="w-4 h-4" />}
+          label={t('observability.duration', 'Duration')}
+          value={formatDuration(span.durationMs)}
+        />
+        {span.tokenInput !== null && (
+          <InfoCard
+            icon={<Hash className="w-4 h-4" />}
+            label={t('observability.inputTokens', 'Input Tokens')}
+            value={formatTokens(span.tokenInput)}
+          />
+        )}
+        {span.tokenOutput !== null && (
+          <InfoCard
+            icon={<Hash className="w-4 h-4" />}
+            label={t('observability.outputTokens', 'Output Tokens')}
+            value={formatTokens(span.tokenOutput)}
+          />
+        )}
+        {span.cost !== null && (
+          <InfoCard
+            icon={<Coins className="w-4 h-4" />}
+            label={t('observability.cost', 'Cost')}
+            value={`$${span.cost.toFixed(6)}`}
+          />
+        )}
       </div>
 
       {(argsFull || (args && Object.keys(args).length > 0)) && (
         <>
-          <div className="text-xs font-medium text-muted-foreground mt-2">{t('observability.arguments', 'Arguments')}</div>
+          <div className="text-xs font-medium text-muted-foreground mt-2">
+            {t('observability.arguments', 'Arguments')}
+          </div>
           <div className="border-l-2 border-primary bg-muted/30 rounded-r-md p-3">
-            <pre className="text-xs leading-relaxed whitespace-pre-wrap break-words overflow-y-auto max-h-40 font-mono">{argsFull || JSON.stringify(args, null, 2)}</pre>
+            <pre className="text-xs leading-relaxed whitespace-pre-wrap break-words overflow-y-auto max-h-40 font-mono">
+              {argsFull || JSON.stringify(args, null, 2)}
+            </pre>
           </div>
         </>
       )}
 
       {(resultFull || resultSummary) && (
         <>
-          <div className="text-xs font-medium text-muted-foreground mt-2">{t('observability.result', 'Result')}</div>
+          <div className="text-xs font-medium text-muted-foreground mt-2">
+            {t('observability.result', 'Result')}
+          </div>
           <div
             className="border-l-2 bg-muted/30 rounded-r-md p-3"
-            style={isError ? { borderLeftColor: '#ef4444', backgroundColor: 'rgba(239,68,68,0.05)' } : { borderLeftColor: '#22c55e' }}
+            style={
+              isError
+                ? { borderLeftColor: '#ef4444', backgroundColor: 'rgba(239,68,68,0.05)' }
+                : { borderLeftColor: '#22c55e' }
+            }
           >
             <pre
               className="text-xs leading-relaxed whitespace-pre-wrap break-words overflow-y-auto max-h-40 font-mono"
@@ -279,16 +372,22 @@ const ToolCallDetail = memo<{ span: Span }>(({ span }) => {
 
       {error && (
         <>
-          <div className="text-xs font-medium text-destructive mt-2">{t('observability.status.error', 'Error')}</div>
+          <div className="text-xs font-medium text-destructive mt-2">
+            {t('observability.status.error', 'Error')}
+          </div>
           <div className="border-l-2 border-destructive bg-destructive/5 rounded-r-md p-3">
-            <pre className="text-xs leading-relaxed whitespace-pre-wrap break-words overflow-y-auto max-h-40 font-mono text-destructive">{error}</pre>
+            <pre className="text-xs leading-relaxed whitespace-pre-wrap break-words overflow-y-auto max-h-40 font-mono text-destructive">
+              {error}
+            </pre>
           </div>
         </>
       )}
 
       <Separator className="my-2" />
 
-      <div className="text-xs font-medium text-muted-foreground">{t('observability.rawAttributes', 'Raw Attributes')}</div>
+      <div className="text-xs font-medium text-muted-foreground">
+        {t('observability.rawAttributes', 'Raw Attributes')}
+      </div>
       <div className="bg-muted/60 rounded-md p-3 overflow-x-auto">
         <pre className="text-[11px] font-mono">{JSON.stringify(span.attributes, null, 2)}</pre>
       </div>
@@ -296,6 +395,119 @@ const ToolCallDetail = memo<{ span: Span }>(({ span }) => {
   );
 });
 ToolCallDetail.displayName = 'ToolCallDetail';
+
+const SkillUseDetail = memo<{ span: Span }>(({ span }) => {
+  const { t } = useTranslation('setting');
+  const skillName = span.attributes?.skillName as string | undefined;
+  const skillAction = span.attributes?.skillAction as string | undefined;
+  const skillFilePath = span.attributes?.skillFilePath as string | undefined;
+  const toolName = span.attributes?.tool as string | undefined;
+  const isError = span.attributes?.isError as boolean | undefined;
+  const argsFull = span.attributes?.argsFull as string | undefined;
+  const resultSummary = span.attributes?.resultSummary as string | undefined;
+  const resultFull = span.attributes?.resultFull as string | undefined;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2 mb-1">
+        <BookOpen className="w-4 h-4 text-teal-500" />
+        <span className="text-sm font-semibold">
+          {t('observability.span.skillUse', 'Skill Use')}
+        </span>
+        <Badge variant="outline" className="text-xs">
+          {span.kind}
+        </Badge>
+        <Badge className="text-xs" variant={span.status === 'ok' ? 'default' : 'destructive'}>
+          {span.status === 'ok'
+            ? t('observability.status.success', 'Success')
+            : t('observability.status.error', 'Error')}
+        </Badge>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+        {skillName && (
+          <InfoCard
+            icon={<Hash className="w-4 h-4" />}
+            label={t('observability.skill', 'Skill')}
+            value={skillName}
+          />
+        )}
+        {skillAction && (
+          <InfoCard
+            icon={<Hash className="w-4 h-4" />}
+            label={t('observability.action', 'Action')}
+            value={skillAction}
+          />
+        )}
+        {skillFilePath && (
+          <InfoCard
+            icon={<Hash className="w-4 h-4" />}
+            label={t('observability.file', 'File')}
+            value={skillFilePath}
+          />
+        )}
+        {toolName && (
+          <InfoCard
+            icon={<Hash className="w-4 h-4" />}
+            label={t('observability.tool', 'Tool')}
+            value={toolName}
+          />
+        )}
+        <InfoCard
+          icon={<Clock className="w-4 h-4" />}
+          label={t('observability.duration', 'Duration')}
+          value={formatDuration(span.durationMs)}
+        />
+      </div>
+
+      {argsFull && (
+        <>
+          <div className="text-xs font-medium text-muted-foreground mt-2">
+            {t('observability.arguments', 'Arguments')}
+          </div>
+          <div className="border-l-2 border-primary bg-muted/30 rounded-r-md p-3">
+            <pre className="text-xs leading-relaxed whitespace-pre-wrap break-words overflow-y-auto max-h-40 font-mono">
+              {argsFull}
+            </pre>
+          </div>
+        </>
+      )}
+
+      {(resultFull || resultSummary) && (
+        <>
+          <div className="text-xs font-medium text-muted-foreground mt-2">
+            {t('observability.result', 'Result')}
+          </div>
+          <div
+            className="border-l-2 bg-muted/30 rounded-r-md p-3"
+            style={
+              isError
+                ? { borderLeftColor: '#ef4444', backgroundColor: 'rgba(239,68,68,0.05)' }
+                : { borderLeftColor: '#14b8a6' }
+            }
+          >
+            <pre
+              className="text-xs leading-relaxed whitespace-pre-wrap break-words overflow-y-auto max-h-40 font-mono"
+              style={isError ? { color: '#b91c1c' } : undefined}
+            >
+              {resultFull || resultSummary}
+            </pre>
+          </div>
+        </>
+      )}
+
+      <Separator className="my-2" />
+
+      <div className="text-xs font-medium text-muted-foreground">
+        {t('observability.rawAttributes', 'Raw Attributes')}
+      </div>
+      <div className="bg-muted/60 rounded-md p-3 overflow-x-auto">
+        <pre className="text-[11px] font-mono">{JSON.stringify(span.attributes, null, 2)}</pre>
+      </div>
+    </div>
+  );
+});
+SkillUseDetail.displayName = 'SkillUseDetail';
 
 const ContextCompressionDetail = memo<{ span: Span }>(({ span }) => {
   const { t } = useTranslation('setting');
@@ -308,22 +520,58 @@ const ContextCompressionDetail = memo<{ span: Span }>(({ span }) => {
     <div className="space-y-3">
       <div className="flex items-center gap-2 mb-1">
         <Cpu className="w-4 h-4 text-orange-500" />
-        <span className="text-sm font-semibold">{t('observability.span.contextCompression', 'Context Compression')}</span>
-        <Badge variant="outline" className="text-xs">{span.kind}</Badge>
-        <Badge variant="secondary" className="text-xs">{t('observability.status.internal', 'Internal')}</Badge>
+        <span className="text-sm font-semibold">
+          {t('observability.span.contextCompression', 'Context Compression')}
+        </span>
+        <Badge variant="outline" className="text-xs">
+          {span.kind}
+        </Badge>
+        <Badge variant="secondary" className="text-xs">
+          {t('observability.status.internal', 'Internal')}
+        </Badge>
       </div>
 
       <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
-        <InfoCard icon={<Clock className="w-4 h-4" />} label={t('observability.duration', 'Duration')} value={formatDuration(span.durationMs)} />
-        {tokensBefore !== undefined && <InfoCard icon={<Hash className="w-4 h-4" />} label={t('observability.tokensBefore', 'Tokens Before')} value={tokensBefore.toLocaleString()} />}
-        {tokensAfter !== undefined && <InfoCard icon={<Hash className="w-4 h-4" />} label={t('observability.tokensAfter', 'Tokens After')} value={tokensAfter.toLocaleString()} />}
-        {saved !== undefined && <InfoCard icon={<Hash className="w-4 h-4" />} label={t('observability.saved', 'Saved')} value={`${saved.toLocaleString()}${savedPct ? ` (${savedPct}%)` : ''}`} />}
-        {span.cost !== null && <InfoCard icon={<Coins className="w-4 h-4" />} label={t('observability.cost', 'Cost')} value={`$${span.cost.toFixed(6)}`} />}
+        <InfoCard
+          icon={<Clock className="w-4 h-4" />}
+          label={t('observability.duration', 'Duration')}
+          value={formatDuration(span.durationMs)}
+        />
+        {tokensBefore !== undefined && (
+          <InfoCard
+            icon={<Hash className="w-4 h-4" />}
+            label={t('observability.tokensBefore', 'Tokens Before')}
+            value={tokensBefore.toLocaleString()}
+          />
+        )}
+        {tokensAfter !== undefined && (
+          <InfoCard
+            icon={<Hash className="w-4 h-4" />}
+            label={t('observability.tokensAfter', 'Tokens After')}
+            value={tokensAfter.toLocaleString()}
+          />
+        )}
+        {saved !== undefined && (
+          <InfoCard
+            icon={<Hash className="w-4 h-4" />}
+            label={t('observability.saved', 'Saved')}
+            value={`${saved.toLocaleString()}${savedPct ? ` (${savedPct}%)` : ''}`}
+          />
+        )}
+        {span.cost !== null && (
+          <InfoCard
+            icon={<Coins className="w-4 h-4" />}
+            label={t('observability.cost', 'Cost')}
+            value={`$${span.cost.toFixed(6)}`}
+          />
+        )}
       </div>
 
       <Separator className="my-2" />
 
-      <div className="text-xs font-medium text-muted-foreground">{t('observability.rawAttributes', 'Raw Attributes')}</div>
+      <div className="text-xs font-medium text-muted-foreground">
+        {t('observability.rawAttributes', 'Raw Attributes')}
+      </div>
       <div className="bg-muted/60 rounded-md p-3 overflow-x-auto">
         <pre className="text-[11px] font-mono">{JSON.stringify(span.attributes, null, 2)}</pre>
       </div>
@@ -348,6 +596,8 @@ const SpanDetailPanel = memo<{ span: Span | null }>(({ span }) => {
       return <LLMCallDetail span={span} />;
     case 'tool_call':
       return <ToolCallDetail span={span} />;
+    case 'skill_use':
+      return <SkillUseDetail span={span} />;
     case 'context_compression':
       return <ContextCompressionDetail span={span} />;
     default:
@@ -373,9 +623,8 @@ const SpanRow = memo<{
 
   const spanStart = toTimestamp(span.startTime);
   const startOffset = totalDuration > 0 ? ((spanStart - traceStart) / totalDuration) * 100 : 0;
-  const barWidth = totalDuration > 0 && span.durationMs
-    ? Math.max(2, (span.durationMs / totalDuration) * 100)
-    : 2;
+  const barWidth =
+    totalDuration > 0 && span.durationMs ? Math.max(2, (span.durationMs / totalDuration) * 100) : 2;
 
   const displayName = getDisplayName(span.name, t);
 
@@ -387,14 +636,20 @@ const SpanRow = memo<{
           ${selected ? 'bg-accent border-primary' : 'border-transparent hover:bg-muted/60 hover:border-border'}
         `}
         onClick={() => onSelect(span.id)}
-        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onSelect(span.id); }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') onSelect(span.id);
+        }}
         role="button"
         tabIndex={0}
       >
         <div style={{ width: depth * 16, flexShrink: 0 }} />
         <div className="w-4 flex-shrink-0 flex items-center justify-center">
           {hasChildren ? (
-            expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />
+            expanded ? (
+              <ChevronDown size={14} />
+            ) : (
+              <ChevronRight size={14} />
+            )
           ) : (
             <span className="inline-block w-3.5" />
           )}
@@ -427,7 +682,8 @@ const SpanRow = memo<{
 
           {(span.tokenInput != null || span.tokenOutput != null) && (
             <span className="text-[11px] text-muted-foreground w-16 text-right tabular-nums">
-              {(span.tokenInput ?? 0) + (span.tokenOutput ?? 0)} {t('observability.tokensShort', 'tk')}
+              {(span.tokenInput ?? 0) + (span.tokenOutput ?? 0)}{' '}
+              {t('observability.tokensShort', 'tk')}
             </span>
           )}
 
@@ -495,11 +751,17 @@ export default function TraceDetailView({ trace, spans, stats, loading }: TraceD
       {/* Trace Overview Grid */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
         <div className="flex flex-col gap-0.5">
-          <span className="text-xs text-muted-foreground">{t('observability.sessionId', 'Session ID')}</span>
-          <span className="font-mono text-xs truncate" title={trace.sessionId}>{trace.sessionId}</span>
+          <span className="text-xs text-muted-foreground">
+            {t('observability.sessionId', 'Session ID')}
+          </span>
+          <span className="font-mono text-xs truncate" title={trace.sessionId}>
+            {trace.sessionId}
+          </span>
         </div>
         <div className="flex flex-col gap-0.5">
-          <span className="text-xs text-muted-foreground">{t('observability.topicId', 'Topic ID')}</span>
+          <span className="text-xs text-muted-foreground">
+            {t('observability.topicId', 'Topic ID')}
+          </span>
           <span className="font-mono text-xs truncate">{trace.topicId || '-'}</span>
         </div>
         <div className="flex flex-col gap-0.5">
@@ -507,23 +769,33 @@ export default function TraceDetailView({ trace, spans, stats, loading }: TraceD
           <span className="truncate">{trace.agentName}</span>
         </div>
         <div className="flex flex-col gap-0.5">
-          <span className="text-xs text-muted-foreground">{t('observability.status', 'Status')}</span>
+          <span className="text-xs text-muted-foreground">
+            {t('observability.status', 'Status')}
+          </span>
           <span className="capitalize">{trace.status}</span>
         </div>
         <div className="flex flex-col gap-0.5">
-          <span className="text-xs text-muted-foreground">{t('observability.inputTokens', 'Input Tokens')}</span>
+          <span className="text-xs text-muted-foreground">
+            {t('observability.inputTokens', 'Input Tokens')}
+          </span>
           <span className="font-mono tabular-nums">{formatTokens(trace.inputTokens)}</span>
         </div>
         <div className="flex flex-col gap-0.5">
-          <span className="text-xs text-muted-foreground">{t('observability.outputTokens', 'Output Tokens')}</span>
+          <span className="text-xs text-muted-foreground">
+            {t('observability.outputTokens', 'Output Tokens')}
+          </span>
           <span className="font-mono tabular-nums">{formatTokens(trace.outputTokens)}</span>
         </div>
         <div className="flex flex-col gap-0.5">
-          <span className="text-xs text-muted-foreground">{t('observability.inputCost', 'Input Cost')}</span>
+          <span className="text-xs text-muted-foreground">
+            {t('observability.inputCost', 'Input Cost')}
+          </span>
           <span className="font-mono tabular-nums">${trace.inputCost.toFixed(6)}</span>
         </div>
         <div className="flex flex-col gap-0.5">
-          <span className="text-xs text-muted-foreground">{t('observability.outputCost', 'Output Cost')}</span>
+          <span className="text-xs text-muted-foreground">
+            {t('observability.outputCost', 'Output Cost')}
+          </span>
           <span className="font-mono tabular-nums">${trace.outputCost.toFixed(6)}</span>
         </div>
       </div>
@@ -543,17 +815,23 @@ export default function TraceDetailView({ trace, spans, stats, loading }: TraceD
       {stats && (
         <div className="flex flex-wrap gap-3 text-sm">
           <div className="flex items-center gap-1.5">
-            <span className="text-muted-foreground">{t('observability.spanStats', 'Span Stats')}:</span>
+            <span className="text-muted-foreground">
+              {t('observability.spanStats', 'Span Stats')}:
+            </span>
             <Badge variant="outline">{stats.totalSpans} spans</Badge>
           </div>
           {stats.errorSpans > 0 && (
             <div className="flex items-center gap-1.5">
-              <span className="text-muted-foreground">{t('observability.errorSpans', 'Error Spans')}:</span>
+              <span className="text-muted-foreground">
+                {t('observability.errorSpans', 'Error Spans')}:
+              </span>
               <Badge variant="destructive">{stats.errorSpans}</Badge>
             </div>
           )}
           <div className="flex items-center gap-1.5">
-            <span className="text-muted-foreground">{t('observability.avgDuration', 'Avg Duration')}:</span>
+            <span className="text-muted-foreground">
+              {t('observability.avgDuration', 'Avg Duration')}:
+            </span>
             <span>{formatDuration(stats.avgDurationMs)}</span>
           </div>
         </div>
@@ -564,7 +842,9 @@ export default function TraceDetailView({ trace, spans, stats, loading }: TraceD
         <div className="space-y-2">
           {/* Timeline Header */}
           <div className="flex items-center px-2 py-1 text-[11px] text-muted-foreground">
-            <span className="flex-1">{t('observability.executionTimeline', 'Execution Timeline')}</span>
+            <span className="flex-1">
+              {t('observability.executionTimeline', 'Execution Timeline')}
+            </span>
             <div className="w-[120px] h-1 bg-muted rounded-sm mx-3 relative flex-shrink-0 overflow-hidden">
               <div className="absolute inset-0 bg-black/5 rounded-sm" />
             </div>

--- a/src/app/(pages)/setting/observability/page.tsx
+++ b/src/app/(pages)/setting/observability/page.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'next/navigation';
 import {
   IconRefresh,
-  IconChevronRight,
   IconCheck,
   IconX,
   IconLoader2,
@@ -23,10 +22,12 @@ import {
   SelectValue,
 } from '@renderer/components/ui/select';
 import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@renderer/components/ui/collapsible';
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@renderer/components/ui/dialog';
 import TraceDetailView, {
   type Trace,
   type Span,
@@ -47,7 +48,7 @@ export default function ObservabilityPage() {
   const [traceDetailMap, setTraceDetailMap] = React.useState<Record<string, TraceDetailData>>({});
   const [detailLoadingMap, setDetailLoadingMap] = React.useState<Record<string, boolean>>({});
   const [loading, setLoading] = React.useState(true);
-  const [expandedTraces, setExpandedTraces] = React.useState<Set<string>>(new Set());
+  const [selectedTraceId, setSelectedTraceId] = React.useState<string | null>(null);
 
   // Filters
   const [sessionId, setSessionId] = React.useState('');
@@ -310,97 +311,105 @@ export default function ObservabilityPage() {
             </div>
           ) : (
             <div className="space-y-2">
-              {filteredTraces.map((trace) => {
-                const detail = traceDetailMap[trace.id];
-                const isDetailLoading = detailLoadingMap[trace.id];
-
-                return (
-                  <div key={trace.id} className="rounded-lg border">
-                    {/* Trace Row */}
-                    <div className="flex items-center justify-between p-3 hover:bg-accent transition-colors">
-                      <div className="flex items-center gap-3 flex-1 min-w-0">
-                        <div className="flex flex-col min-w-0">
-                          <div className="flex items-center gap-2 flex-wrap">
-                            <span className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded">
-                              {trace.id.slice(0, 12)}
-                            </span>
-                            {getStatusBadge(trace.status)}
-                            {trace.metadata && !!(trace.metadata as Record<string, unknown>).reflectionTriggered && (
-                              <Badge variant="outline" className="text-[10px] h-5">
-                                {t('observability.reflectionTriggered', 'Reflection')}
-                              </Badge>
-                            )}
-                          </div>
-                          <div className="text-xs text-muted-foreground mt-0.5">
-                            {trace.agentName} &middot; {formatDate(trace.createdAt)}
-                          </div>
+              {filteredTraces.map((trace) => (
+                <div
+                  key={trace.id}
+                  className="rounded-lg border p-3 hover:bg-accent transition-colors cursor-pointer"
+                  onClick={() => {
+                    setSelectedTraceId(trace.id);
+                    if (!traceDetailMap[trace.id] && !detailLoadingMap[trace.id]) {
+                      fetchTraceDetail(trace.id);
+                    }
+                  }}
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-3 flex-1 min-w-0">
+                      <div className="flex flex-col min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <span className="text-sm font-medium truncate max-w-[400px]">
+                            {trace.input || (trace.metadata as Record<string, unknown>)?.input as string || trace.id.slice(0, 12)}
+                          </span>
+                          {getStatusBadge(trace.status)}
+                          {trace.metadata && !!(trace.metadata as Record<string, unknown>).reflectionTriggered && (
+                            <Badge variant="outline" className="text-[10px] h-5">
+                              {t('observability.reflectionTriggered', 'Reflection')}
+                            </Badge>
+                          )}
                         </div>
-                      </div>
-                      <div className="flex items-center gap-4 text-xs flex-shrink-0">
-                        <div className="flex flex-col items-end">
-                          <span className="font-medium tabular-nums">{formatTokens(trace.totalTokens)}</span>
-                          <span className="text-muted-foreground text-[10px]">tokens</span>
+                        <div className="text-xs text-muted-foreground mt-0.5">
+                          <span className="font-mono">{trace.id.slice(0, 12)}</span>
+                          {' · '}
+                          {trace.agentName} &middot; {formatDate(trace.createdAt)}
                         </div>
-                        <div className="flex flex-col items-end">
-                          <span className="font-medium tabular-nums">{formatCost(trace.totalCost)}</span>
-                          <span className="text-muted-foreground text-[10px]">cost</span>
-                        </div>
-                        <div className="flex flex-col items-end">
-                          <span className="font-medium tabular-nums">{formatDuration(trace.latencyMs)}</span>
-                          <span className="text-muted-foreground text-[10px]">latency</span>
-                        </div>
-                        {trace.toolCallCount > 0 && (
-                          <div className="flex flex-col items-end">
-                            <span className="font-medium tabular-nums">{trace.toolCallCount}</span>
-                            <span className="text-muted-foreground text-[10px]">tools</span>
-                          </div>
-                        )}
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="h-7 px-2 text-xs"
-                          onClick={() => {
-                            const isExpanded = expandedTraces.has(trace.id);
-                            if (isExpanded) {
-                              setExpandedTraces((prev) => {
-                                const next = new Set(prev);
-                                next.delete(trace.id);
-                                return next;
-                              });
-                            } else {
-                              if (!detail && !isDetailLoading) {
-                                fetchTraceDetail(trace.id);
-                              }
-                              setExpandedTraces((prev) => new Set(prev).add(trace.id));
-                            }
-                          }}
-                        >
-                          <IconChevronRight
-                            className={`h-4 w-4 mr-1 transition-transform ${expandedTraces.has(trace.id) ? 'rotate-90' : ''}`}
-                          />
-                          {expandedTraces.has(trace.id)
-                            ? t('observability.collapse', 'Collapse')
-                            : t('observability.expand', 'Details')}
-                        </Button>
                       </div>
                     </div>
-
-                    {/* Trace Detail — rendered inline immediately below the row */}
-                    {expandedTraces.has(trace.id) && (
-                      <div className="border-t">
-                        <TraceDetailView
-                          loading={!!isDetailLoading}
-                          spans={detail?.spans ?? []}
-                          stats={detail?.stats ?? null}
-                          trace={trace}
-                        />
+                    <div className="flex items-center gap-4 text-xs flex-shrink-0">
+                      <div className="flex flex-col items-end">
+                        <span className="font-medium tabular-nums">{formatTokens(trace.totalTokens)}</span>
+                        <span className="text-muted-foreground text-[10px]">tokens</span>
                       </div>
-                    )}
+                      <div className="flex flex-col items-end">
+                        <span className="font-medium tabular-nums">{formatCost(trace.totalCost)}</span>
+                        <span className="text-muted-foreground text-[10px]">cost</span>
+                      </div>
+                      <div className="flex flex-col items-end">
+                        <span className="font-medium tabular-nums">{formatDuration(trace.latencyMs)}</span>
+                        <span className="text-muted-foreground text-[10px]">latency</span>
+                      </div>
+                      {trace.toolCallCount > 0 && (
+                        <div className="flex flex-col items-end">
+                          <span className="font-medium tabular-nums">{trace.toolCallCount}</span>
+                          <span className="text-muted-foreground text-[10px]">tools</span>
+                        </div>
+                      )}
+                    </div>
                   </div>
-                );
-              })}
+                </div>
+              ))}
             </div>
           )}
+
+          {/* Trace Detail Dialog */}
+          {(() => {
+            const selectedTrace = selectedTraceId ? filteredTraces.find((t) => t.id === selectedTraceId) : null;
+            const detail = selectedTraceId ? traceDetailMap[selectedTraceId] : null;
+            const isDetailLoading = selectedTraceId ? detailLoadingMap[selectedTraceId] : false;
+
+            return (
+              <Dialog open={!!selectedTrace} onOpenChange={(open) => { if (!open) setSelectedTraceId(null); }}>
+                <DialogContent className="sm:max-w-[90vw] max-h-[85vh] overflow-y-auto">
+                  {selectedTrace && (
+                    <>
+                      <DialogHeader>
+                        <DialogTitle className="flex items-center gap-2">
+                          <span className="font-mono text-sm bg-muted px-2 py-0.5 rounded">
+                            {selectedTrace.id.slice(0, 12)}
+                          </span>
+                          <span>{selectedTrace.agentName}</span>
+                          {getStatusBadge(selectedTrace.status)}
+                        </DialogTitle>
+                        <DialogDescription>
+                          {formatDate(selectedTrace.createdAt)}
+                          {' · '}
+                          {formatTokens(selectedTrace.totalTokens)} tokens
+                          {' · '}
+                          {formatCost(selectedTrace.totalCost)}
+                          {' · '}
+                          {formatDuration(selectedTrace.latencyMs)}
+                        </DialogDescription>
+                      </DialogHeader>
+                      <TraceDetailView
+                        loading={!!isDetailLoading}
+                        spans={detail?.spans ?? []}
+                        stats={detail?.stats ?? null}
+                        trace={selectedTrace}
+                      />
+                    </>
+                  )}
+                </DialogContent>
+              </Dialog>
+            );
+          })()}
 
           {/* Pagination */}
           <div className="flex items-center justify-between mt-4">

--- a/src/app/api/observability/[traceId]/route.ts
+++ b/src/app/api/observability/[traceId]/route.ts
@@ -1,87 +1,15 @@
-/**
- * Single Trace Detail API
- *
- * GET /api/observability/[traceId] - 获取单个 trace 详情
- */
-import { NextRequest, NextResponse } from 'next/server';
-import { observabilityTraceRepository, observabilitySpanRepository } from '@server/repository/chat/observability';
+import { BaseController } from '../../base/baseController';
+import { ObservabilityBizController } from '@server/controller/observability';
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ traceId: string }> }
-) {
-  try {
+class ObservabilityDetailHttpController extends BaseController {
+  static async GET(
+    request: Request,
+    { params }: { params: Promise<{ traceId: string }> }
+  ) {
+    const controller = new ObservabilityBizController();
     const { traceId } = await params;
-
-    const trace = await observabilityTraceRepository.findById(traceId);
-    if (!trace) {
-      return NextResponse.json(
-        { success: false, error: 'Trace not found' },
-        { status: 404 }
-      );
-    }
-
-    // 获取所有 spans
-    const spans = await observabilitySpanRepository.findByTraceId(traceId);
-
-    // 获取 span 统计
-    const stats = await observabilitySpanRepository.getSpanStats(traceId);
-
-    // 构建 span 树结构
-    const spanTree = buildSpanTree(spans);
-
-    return NextResponse.json({
-      success: true,
-      data: {
-        trace,
-        spans,
-        spanTree,
-        stats,
-      },
-    });
-  } catch (error) {
-    console.error('[Observability API] GET trace error:', error);
-    return NextResponse.json(
-      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
-      { status: 500 }
-    );
+    return Response.json(await controller.getTraceDetail({ traceId }));
   }
 }
 
-interface SpanNode {
-  id: string;
-  name: string;
-  durationMs: number | null;
-  status: string;
-  children: SpanNode[];
-  [key: string]: any;
-}
-
-function buildSpanTree(spans: any[]): SpanNode[] {
-  const nodes: Record<string, SpanNode> = {};
-  const roots: SpanNode[] = [];
-
-  // 先构建所有节点
-  for (const span of spans) {
-    nodes[span.id] = {
-      id: span.id,
-      name: span.name,
-      durationMs: span.durationMs,
-      status: span.status,
-      children: [],
-      ...span,
-    };
-  }
-
-  // 构建树结构
-  for (const span of spans) {
-    const node = nodes[span.id];
-    if (span.parentSpanId && nodes[span.parentSpanId]) {
-      nodes[span.parentSpanId].children.push(node);
-    } else {
-      roots.push(node);
-    }
-  }
-
-  return roots;
-}
+export const GET = ObservabilityDetailHttpController.GET;

--- a/src/app/api/observability/route.ts
+++ b/src/app/api/observability/route.ts
@@ -1,68 +1,12 @@
-/**
- * Observability History API
- *
- * GET /api/observability - 查询历史 traces
- * 支持分页、过滤和统计查询
- */
-import { NextRequest, NextResponse } from 'next/server';
-import { observabilityTraceRepository, observabilitySpanRepository } from '@server/repository/chat/observability';
-import { z } from 'zod';
+import { BaseController } from '../base/baseController';
+import { ObservabilityBizController } from '@server/controller/observability';
 
-const QuerySchema = z.object({
-  sessionId: z.string().optional(),
-  topicId: z.string().optional(),
-  status: z.enum(['running', 'completed', 'error']).optional(),
-  agentName: z.string().optional(),
-  limit: z.coerce.number().min(1).max(100).default(20),
-  offset: z.coerce.number().min(0).default(0),
-  includeSpans: z.coerce.boolean().default(false),
-});
-
-export async function GET(request: NextRequest) {
-  try {
-    const { searchParams } = new URL(request.url);
-    const params = Object.fromEntries(searchParams.entries());
-    const query = QuerySchema.parse(params);
-
-    let traces;
-    if (query.sessionId) {
-      traces = await observabilityTraceRepository.findBySessionId(query.sessionId, {
-        limit: query.limit,
-        offset: query.offset,
-      });
-    } else if (query.topicId) {
-      traces = await observabilityTraceRepository.findByTopicId(query.topicId);
-    } else if (query.status) {
-      traces = await observabilityTraceRepository.findByStatus(query.status, { limit: query.limit });
-    } else {
-      traces = await observabilityTraceRepository.findRecent({ limit: query.limit });
-    }
-
-    // 可选：加载每个 trace 的 spans
-    let tracesWithSpans = traces;
-    if (query.includeSpans) {
-      tracesWithSpans = await Promise.all(
-        traces.map(async (trace) => {
-          const spans = await observabilitySpanRepository.findByTraceId(trace.id);
-          return { ...trace, spans };
-        })
-      );
-    }
-
-    return NextResponse.json({
-      success: true,
-      data: tracesWithSpans,
-      pagination: {
-        limit: query.limit,
-        offset: query.offset,
-        total: traces.length,
-      },
-    });
-  } catch (error) {
-    console.error('[Observability API] GET error:', error);
-    return NextResponse.json(
-      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
-      { status: 400 }
-    );
+class ObservabilityHttpController extends BaseController {
+  static async GET(request: Request) {
+    const controller = new ObservabilityBizController();
+    const query = await super.getQuery(request);
+    return Response.json(await controller.getTraces(query));
   }
 }
+
+export const GET = ObservabilityHttpController.GET;

--- a/src/app/hooks/__tests__/useNotifications.test.ts
+++ b/src/app/hooks/__tests__/useNotifications.test.ts
@@ -56,11 +56,16 @@ describe('useNotifications', () => {
   });
 
   const createResponse = (items: any[], unreadCount = items.length) => ({
-    items,
-    totalCount: items.length,
-    unreadCount,
-    totalPages: 1,
-    currentPage: 1,
+    success: true,
+    data: {
+      items,
+      totalCount: items.length,
+      unreadCount,
+      totalPages: 1,
+      currentPage: 1,
+    },
+    message: 'ok',
+    code: 'SUCCESS',
   });
 
   it('应该在挂载时初始化轮询', async () => {

--- a/src/app/hooks/useNotifications.ts
+++ b/src/app/hooks/useNotifications.ts
@@ -13,6 +13,13 @@ import type {
   NotificationTypeValue,
   NotificationPriorityValue,
 } from '@/types/notification';
+
+interface ApiResponse<T> {
+  success: boolean;
+  data: T;
+  message: string;
+  code: string;
+}
 import { useNotificationStore } from '@/app/store/notification';
 
 const POLL_INTERVAL_MS = 60000;
@@ -84,9 +91,10 @@ export function useNotifications(): UseNotificationsReturn {
   const poll = useCallback(async () => {
     setIsLoading(true);
     try {
-      const response = await get<NotificationListResponseType>('/api/notifications', {
+      const raw = await get<ApiResponse<NotificationListResponseType>>('/api/notifications', {
         params: { isRead: 'unread', pageSize: 50 },
       });
+      const response = raw.data;
 
       setNotifications(response.items);
       setUnreadCount(response.unreadCount);

--- a/src/app/store/observability/store.ts
+++ b/src/app/store/observability/store.ts
@@ -7,7 +7,7 @@ export interface SpanData {
   spanId: string;
   traceId: string;
   parentSpanId?: string;
-  name: 'llm_call' | 'tool_call' | 'context_compression';
+  name: 'llm_call' | 'tool_call' | 'skill_use' | 'context_compression';
   kind: 'client' | 'internal';
   status: 'ok' | 'error';
   startTime: number;
@@ -67,7 +67,7 @@ export interface ObservabilityActions {
     traceId: string;
     spanId: string;
     parentSpanId?: string;
-    name: 'llm_call' | 'tool_call' | 'context_compression';
+    name: 'llm_call' | 'tool_call' | 'skill_use' | 'context_compression';
     kind: 'client' | 'internal';
     startTime: number;
     attributes?: Record<string, unknown>;
@@ -194,7 +194,17 @@ export const useObservabilityStore = createWithEqualityFn<ObservabilityStore>()(
         );
       },
 
-      handleSpanEnd: ({ traceId, spanId, status, endTime, durationMs, attributes, tokenInput, tokenOutput, cost }) => {
+      handleSpanEnd: ({
+        traceId,
+        spanId,
+        status,
+        endTime,
+        durationMs,
+        attributes,
+        tokenInput,
+        tokenOutput,
+        cost,
+      }) => {
         set(
           produce(get(), (draft) => {
             const spans = draft.spansByTraceId[traceId];

--- a/src/app/store/observability/store.ts
+++ b/src/app/store/observability/store.ts
@@ -2,12 +2,13 @@ import { devtools } from 'zustand/middleware';
 import { createWithEqualityFn } from 'zustand/traditional';
 import { shallow } from 'zustand/shallow';
 import { produce } from 'immer';
+import type { SpanName } from '@investment-agent/hermes-agent';
 
 export interface SpanData {
   spanId: string;
   traceId: string;
   parentSpanId?: string;
-  name: 'llm_call' | 'tool_call' | 'skill_use' | 'context_compression';
+  name: SpanName;
   kind: 'client' | 'internal';
   status: 'ok' | 'error';
   startTime: number;
@@ -67,7 +68,7 @@ export interface ObservabilityActions {
     traceId: string;
     spanId: string;
     parentSpanId?: string;
-    name: 'llm_call' | 'tool_call' | 'skill_use' | 'context_compression';
+    name: SpanName;
     kind: 'client' | 'internal';
     startTime: number;
     attributes?: Record<string, unknown>;

--- a/src/locales/en-US/chat.json
+++ b/src/locales/en-US/chat.json
@@ -153,6 +153,7 @@
     "span": {
       "llmCall": "LLM Call",
       "toolCall": "Tool Call",
+      "skillUse": "Skill Use",
       "contextCompression": "Context Compression"
     },
     "status": {
@@ -169,6 +170,9 @@
     "output": "Output",
     "rawAttributes": "Raw Attributes",
     "tool": "Tool",
+    "skill": "Skill",
+    "action": "Action",
+    "file": "File",
     "arguments": "Arguments",
     "result": "Result",
     "tokensBefore": "Tokens Before",

--- a/src/locales/en-US/setting.json
+++ b/src/locales/en-US/setting.json
@@ -646,6 +646,7 @@
     "span": {
       "llmCall": "LLM Call",
       "toolCall": "Tool Call",
+      "skillUse": "Skill Use",
       "contextCompression": "Context Compression"
     },
     "model": "Model",
@@ -653,6 +654,9 @@
     "inputPrompt": "Input Prompt",
     "output": "Output",
     "tool": "Tool",
+    "skill": "Skill",
+    "action": "Action",
+    "file": "File",
     "arguments": "Arguments",
     "result": "Result",
     "saved": "Saved",

--- a/src/locales/zh-CN/chat.json
+++ b/src/locales/zh-CN/chat.json
@@ -152,6 +152,7 @@
     "span": {
       "llmCall": "LLM 调用",
       "toolCall": "工具调用",
+      "skillUse": "技能使用",
       "contextCompression": "上下文压缩"
     },
     "status": {
@@ -168,6 +169,9 @@
     "output": "输出",
     "rawAttributes": "原始属性",
     "tool": "工具",
+    "skill": "技能",
+    "action": "动作",
+    "file": "文件",
     "arguments": "参数",
     "result": "结果",
     "tokensBefore": "压缩前 Token",

--- a/src/locales/zh-CN/setting.json
+++ b/src/locales/zh-CN/setting.json
@@ -718,6 +718,7 @@
     "span": {
       "llmCall": "LLM 调用",
       "toolCall": "工具调用",
+      "skillUse": "技能使用",
       "contextCompression": "上下文压缩"
     },
     "model": "模型",
@@ -725,6 +726,9 @@
     "inputPrompt": "输入提示词",
     "output": "输出结果",
     "tool": "工具",
+    "skill": "技能",
+    "action": "动作",
+    "file": "文件",
     "arguments": "参数",
     "result": "结果",
     "saved": "节省",

--- a/src/server/controller/observability.ts
+++ b/src/server/controller/observability.ts
@@ -1,0 +1,140 @@
+import { BaseBizController } from './base';
+import { observabilityTraceRepository, observabilitySpanRepository } from '@server/repository/chat/observability';
+import { observabilityService } from '@server/service/observabilityService';
+import logger from '@server/base/logger';
+import { z } from 'zod';
+
+const QuerySchema = z.object({
+  sessionId: z.string().optional(),
+  topicId: z.string().optional(),
+  status: z.enum(['running', 'completed', 'error']).optional(),
+  agentName: z.string().optional(),
+  limit: z.coerce.number().min(1).max(100).default(20),
+  offset: z.coerce.number().min(0).default(0),
+  includeSpans: z.coerce.boolean().default(false),
+});
+
+interface SpanNode {
+  id: string;
+  name: string;
+  durationMs: number | null;
+  status: string;
+  children: SpanNode[];
+  [key: string]: any;
+}
+
+function buildSpanTree(spans: any[]): SpanNode[] {
+  const nodes: Record<string, SpanNode> = {};
+  const roots: SpanNode[] = [];
+
+  for (const span of spans) {
+    nodes[span.id] = {
+      id: span.id,
+      name: span.name,
+      durationMs: span.durationMs,
+      status: span.status,
+      children: [],
+      ...span,
+    };
+  }
+
+  for (const span of spans) {
+    const node = nodes[span.id];
+    if (span.parentSpanId && nodes[span.parentSpanId]) {
+      nodes[span.parentSpanId].children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  return roots;
+}
+
+export class ObservabilityBizController extends BaseBizController {
+  // ============== 查询操作 ==============
+
+  /**
+   * 查询 trace 列表
+   * @param query 查询参数
+   */
+  async getTraces(query: Record<string, unknown>) {
+    try {
+      const parsed = QuerySchema.safeParse(query);
+      if (!parsed.success) {
+        return this.error('Invalid query parameters', 'validation_error');
+      }
+      const params = parsed.data;
+
+      let traces;
+      if (params.sessionId) {
+        traces = await observabilityTraceRepository.findBySessionId(params.sessionId, {
+          limit: params.limit,
+          offset: params.offset,
+        });
+      } else if (params.topicId) {
+        traces = await observabilityTraceRepository.findByTopicId(params.topicId);
+      } else if (params.status) {
+        traces = await observabilityTraceRepository.findByStatus(params.status, { limit: params.limit });
+      } else {
+        traces = await observabilityTraceRepository.findRecent({ limit: params.limit });
+      }
+
+      // Enrich traces with user input query from chat_messages
+      const traceIds = traces.map((t) => t.id);
+      const inputMap = await observabilityService.getTraceInputs(traceIds);
+
+      const enrichedTraces = traces.map((trace) => ({
+        ...trace,
+        input: inputMap.get(trace.id) ?? null,
+      }));
+
+      let result = enrichedTraces;
+      if (params.includeSpans) {
+        result = await Promise.all(
+          enrichedTraces.map(async (trace) => {
+            const spans = await observabilitySpanRepository.findByTraceId(trace.id);
+            return { ...trace, spans };
+          })
+        );
+      }
+
+      return this.success(result);
+    } catch (error) {
+      logger.error('[ObservabilityBizController] Failed to get traces:', error);
+      return this.error(
+        error instanceof Error ? error.message : 'Failed to get traces',
+        'get_traces_error',
+      );
+    }
+  }
+
+  /**
+   * 查询单个 trace 详情
+   * @param params 包含 traceId
+   */
+  async getTraceDetail(params: { traceId: string }) {
+    try {
+      const trace = await observabilityTraceRepository.findById(params.traceId);
+      if (!trace) {
+        return this.error('Trace not found', 'trace_not_found');
+      }
+
+      const spans = await observabilitySpanRepository.findByTraceId(params.traceId);
+      const stats = await observabilitySpanRepository.getSpanStats(params.traceId);
+      const spanTree = buildSpanTree(spans);
+
+      return this.success({
+        trace,
+        spans,
+        spanTree,
+        stats,
+      });
+    } catch (error) {
+      logger.error('[ObservabilityBizController] Failed to get trace detail:', error);
+      return this.error(
+        error instanceof Error ? error.message : 'Failed to get trace detail',
+        'get_trace_detail_error',
+      );
+    }
+  }
+}

--- a/src/server/repository/chat/span.ts
+++ b/src/server/repository/chat/span.ts
@@ -12,7 +12,7 @@ export type SpanEntity = {
   id: string;
   traceId: string;
   parentSpanId: string | null;
-  name: 'llm_call' | 'tool_call' | 'context_compression';
+  name: 'llm_call' | 'tool_call' | 'skill_use' | 'context_compression';
   kind: 'client' | 'internal';
   status: 'ok' | 'error';
   attributes: Record<string, unknown> | null;

--- a/src/server/repository/chat/span.ts
+++ b/src/server/repository/chat/span.ts
@@ -6,13 +6,14 @@
 import { db } from '@server/lib/db';
 import { chatSpans } from '@/drizzle/schema';
 import { eq } from 'drizzle-orm';
+import type { SpanName } from '@investment-agent/hermes-agent';
 import { BaseRepository } from './base';
 
 export type SpanEntity = {
   id: string;
   traceId: string;
   parentSpanId: string | null;
-  name: 'llm_call' | 'tool_call' | 'skill_use' | 'context_compression';
+  name: SpanName;
   kind: 'client' | 'internal';
   status: 'ok' | 'error';
   attributes: Record<string, unknown> | null;

--- a/src/server/service/observabilityService.ts
+++ b/src/server/service/observabilityService.ts
@@ -8,7 +8,7 @@
  */
 import { traceRepository, spanRepository } from '@server/repository/chat';
 import { db } from '@server/lib/db';
-import { chatMessages } from '@/drizzle/schema/chat';
+import { chatMessages } from '@drizzle/schema/chat';
 import { eq, and, asc, inArray } from 'drizzle-orm';
 import logger from '@server/base/logger';
 import type {

--- a/src/server/service/observabilityService.ts
+++ b/src/server/service/observabilityService.ts
@@ -7,6 +7,9 @@
  * 关键：确保 trace 在 span 之前创建，避免外键约束失败。
  */
 import { traceRepository, spanRepository } from '@server/repository/chat';
+import { db } from '@server/lib/db';
+import { chatMessages } from '@/drizzle/schema/chat';
+import { eq, and, asc, inArray } from 'drizzle-orm';
 import logger from '@server/base/logger';
 import type {
   TraceStartEvent,
@@ -153,6 +156,37 @@ export class ObservabilityService {
 
   async findSpansByTrace(traceId: string) {
     return spanRepository.findByTraceId(traceId);
+  }
+
+  /**
+   * Batch-lookup first user message per trace from chat_messages.
+   * @param traceIds Trace IDs to look up
+   * @returns Map of traceId → user input text (truncated to 200 chars)
+   */
+  async getTraceInputs(traceIds: string[]): Promise<Map<string, string>> {
+    const inputMap = new Map<string, string>();
+    if (traceIds.length === 0) return inputMap;
+
+    try {
+      const messages = await (db as any)
+        .select({ traceId: chatMessages.traceId, content: chatMessages.content })
+        .from(chatMessages)
+        .where(and(
+          eq(chatMessages.role, 'user'),
+          inArray(chatMessages.traceId, traceIds),
+        ))
+        .orderBy(asc(chatMessages.createdAt));
+
+      for (const msg of messages) {
+        if (msg.traceId && !inputMap.has(msg.traceId)) {
+          inputMap.set(msg.traceId, msg.content?.slice(0, 200) ?? '');
+        }
+      }
+    } catch (error) {
+      logger.error('[ObservabilityService] Failed to get trace inputs:', error);
+    }
+
+    return inputMap;
   }
 }
 

--- a/src/types/agentStream.ts
+++ b/src/types/agentStream.ts
@@ -98,7 +98,7 @@ export type AgentStreamEvent =
       traceId: string;
       spanId: string;
       parentSpanId?: string;
-      name: 'llm_call' | 'tool_call' | 'context_compression';
+      name: 'llm_call' | 'tool_call' | 'skill_use' | 'context_compression';
       kind: 'client' | 'internal';
       startTime: number;
       attributes?: Record<string, unknown>;
@@ -107,7 +107,7 @@ export type AgentStreamEvent =
       type: 'span_end';
       traceId: string;
       spanId: string;
-      name: 'llm_call' | 'tool_call' | 'context_compression';
+      name: 'llm_call' | 'tool_call' | 'skill_use' | 'context_compression';
       status: 'ok' | 'error';
       startTime: number;
       endTime: number;

--- a/src/types/agentStream.ts
+++ b/src/types/agentStream.ts
@@ -1,5 +1,6 @@
 import type { UIArtifactType } from '@typings/chat/uiArtifact';
 import { UI_ARTIFACT_VERSION } from '@typings/chat/uiArtifact';
+import type { SpanName } from '@investment-agent/hermes-agent';
 
 export type AgentStreamEvent =
   | {
@@ -98,7 +99,7 @@ export type AgentStreamEvent =
       traceId: string;
       spanId: string;
       parentSpanId?: string;
-      name: 'llm_call' | 'tool_call' | 'skill_use' | 'context_compression';
+      name: SpanName;
       kind: 'client' | 'internal';
       startTime: number;
       attributes?: Record<string, unknown>;
@@ -107,7 +108,7 @@ export type AgentStreamEvent =
       type: 'span_end';
       traceId: string;
       spanId: string;
-      name: 'llm_call' | 'tool_call' | 'skill_use' | 'context_compression';
+      name: SpanName;
       status: 'ok' | 'error';
       startTime: number;
       endTime: number;


### PR DESCRIPTION
## Summary

- **Skill usage tracking**: hermes-agent now tracks skill invocations during agent loops, exposing them through the observability pipeline
- **Observability API refactor**: extracted route logic into `BaseBizController` + service layer pattern, following project conventions (controller-rule, service-rule)
- **Trace list UI improvements**: display user input query as trace title (with `metadata.input` fallback), replace collapsible with dialog for trace detail view
- **Notifications fix**: add API response type for unread badge display

## Test plan

- [ ] Verify `/api/observability?limit=20&offset=0` returns correct response shape
- [ ] Verify `/api/observability/<traceId>` returns trace detail with spans and stats
- [ ] Verify trace list shows user input query as title
- [ ] Verify clicking a trace opens dialog with detail view
- [ ] Verify sidebar notification unread badge displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added skill-use spans to observability so skill executions are traced and shown with metadata.
  * Trace details now open in a modal and include captured input text (truncated).
* **UI Improvements**
  * Span/timeline and detail views updated for clearer metadata, duration, and status display.
* **Tests**
  * New tests verifying skill tracing and attribute recording.
* **Documentation**
  * Added localization strings for skill telemetry (en/zh).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->