### PR TITLE
fix(api): add missing POST handler for /api/notifications/read-all

### DIFF
--- a/src/app/api/notifications/read-all/route.ts
+++ b/src/app/api/notifications/read-all/route.ts
@@ -1,0 +1,16 @@
+import { WithRequestContext } from '@server/base/decorators';
+import { BaseController } from '../../base/baseController';
+import notificationController from '@/server/controller/notification';
+
+class NotificationMarkAllReadHttpController extends BaseController {
+  /**
+   * POST /api/notifications/read-all - 批量标记所有通知为已读
+   */
+  @WithRequestContext()
+  static async POST(request: Request) {
+    return Response.json(await notificationController.markAllAsRead());
+  }
+}
+
+// 导出对应的 HTTP 方法
+export const POST = NotificationMarkAllReadHttpController.POST;


### PR DESCRIPTION
## Summary

前端在「全部标记已读」时调用 `POST /api/notifications/read-all`，但仓库中不存在该路由文件。Next.js 将 `read-all` 匹配为动态路由 `[id]`（该路由仅导出 `DELETE`），导致请求返回 **405 Method Not Allowed**。

底层 Controller / Service / Repository 的 `markAllAsRead` 逻辑均已存在，仅缺少 HTTP 路由入口。

## Changes

- 新增 `src/app/api/notifications/read-all/route.ts`，导出 `POST` handler，委托给已有的 `notificationController.markAllAsRead()`（静态段优先于动态段 `[id]`，路由可正确解析）。

## Verification

- 本地 dev server 验证: `POST /api/notifications/read-all` → `200 {"success":true,"data":{"count":0},"message":"","code":""}`
- 对照组 `POST /api/notifications/123`（动态 `[id]` 路由）仍返回 405，确认路由解析正确。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to mark all notifications as read at once.
  * The action now provides a clear result after notifications are updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->